### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
+    labels:
+      - "kind/dependencies"
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "daily"
     target-branch: "main"
+    labels:
+      - "kind/dependencies"


### PR DESCRIPTION
Update dependabot.yml so it uses the correct labels on any PRs it opens