### PR TITLE
Re-use hyperlight dev and add wasm specific tools

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,28 +1,15 @@
 ## Dockerfile for devcontainer
 
-FROM mcr.microsoft.com/devcontainers/base:debian AS base
-
+FROM ghcr.io/hyperlight-dev/hyperlight-devcontainer:latest
 ARG USER=vscode
 ARG GROUP=vscode
 
-ENV HOME="/home/${USER}"
-ENV PATH="$HOME/.cargo/bin:$PATH"
+# use root to install tools then switch back to vscode user
+USER root
 
 # Install dependencies
 RUN apt-get update \
     && apt-get -y install \
-        build-essential \
-        cmake \
-        curl \
-        gdb \
-        git \
-        gnupg \
-        gnuplot \
-        lsb-release \
-        make \
-        software-properties-common \
-        sudo \
-        wget \
         netcat-openbsd
 
 ARG GCC_VERSION=12
@@ -31,34 +18,9 @@ RUN apt-get install -y g++-multilib \
     && apt-get install -y libgcc-${GCC_VERSION}-dev \
     && apt-get install -y lib32gcc-${GCC_VERSION}-dev 
 
-ARG LLVM_VERSION=17
-
-# Install llvm
-RUN wget https://apt.llvm.org/llvm.sh \
-    && chmod +x ./llvm.sh         \
-    && sudo ./llvm.sh ${LLVM_VERSION} all      \
-    && sudo ln -s /usr/lib/llvm-${LLVM_VERSION}/bin/clang-cl /usr/bin/clang-cl \
-    && sudo ln -s /usr/lib/llvm-${LLVM_VERSION}/bin/llvm-lib /usr/bin/llvm-lib \
-    && sudo ln -s /usr/lib/llvm-${LLVM_VERSION}/bin/lld-link /usr/bin/lld-link \
-    && sudo ln -s /usr/lib/llvm-${LLVM_VERSION}/bin/llvm-ml /usr/bin/llvm-ml   \
-    && sudo ln -s /usr/lib/llvm-${LLVM_VERSION}/bin/ld.lld /usr/bin/ld.lld     \
-    && sudo ln -s /usr/lib/llvm-${LLVM_VERSION}/bin/clang /usr/bin/clang
-
-FROM base AS dev
-
-# Make sure the devcontainer user has sudo access
-RUN chown -R "${USER}:${GROUP}" /home/${USER} \
-    && echo "${USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
-# Persist bash history
-RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-    && mkdir /commandhistory \
-    && touch /commandhistory/.bash_history \
-    && chown -R "${USER}" /commandhistory \
-    && echo "$SNIPPET" >> "/home/${USER}/.bashrc"
-# Install python3
 ARG WASI_SDK_VERSION_FULL=20.0
 ARG WASI_SDK_VERSION_MAJOR=${WASI_SDK_VERSION_FULL%%.*}
+
 # Install wasi-sdk
 RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION_MAJOR}/wasi-sdk-${WASI_SDK_VERSION_FULL}-linux.tar.gz \
     && tar xvf wasi-sdk-${WASI_SDK_VERSION_FULL}-linux.tar.gz \
@@ -66,16 +28,11 @@ RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WA
     && mv /wasi-sdk-${WASI_SDK_VERSION_FULL}  /opt/wasi-sdk
 
 USER $USER
-
 ARG RUST_TOOLCHAIN=1.82.0
 
-# Install rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    && rustup default ${RUST_TOOLCHAIN} \
-    && rustup target add x86_64-unknown-linux-gnu \
-    && rustup target add x86_64-unknown-none      \
-    && rustup target add x86_64-pc-windows-msvc   \
-    && rustup toolchain add nightly-x86_64-unknown-linux-gnu \
-    && cargo install just \
+# Install rust and component tools
+RUN rustup default ${RUST_TOOLCHAIN} \
     && cargo install --locked wasm-tools \
-    && cargo install wkg
+    && cargo install wkg \
+    && cargo install wac-cli \
+    && cargo install cargo-component --locked


### PR DESCRIPTION
Adds a few wasm specific tools to the container.  This helps devs in general but also helpful for demo dev containers like https://github.com/hyperlight-dev/hyperlight-wasm-calculator-example/pull/1

I also noticed that base container is basically the same as the [hyper-light dev container](https://github.com/hyperlight-dev/hyperlight/blob/main/.devcontainer/Dockerfile) just with wasi specific things so based of that image to reduce needing to maintain those tools in two places.