### PR TITLE
Automatically approve unmodified dependabot requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "03:00"
     target-branch: "main"
     labels:
       - "kind/dependencies"
@@ -11,6 +12,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "03:00"
     target-branch: "main"
     labels:
       - "kind/dependencies"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,49 @@
+name: Auto Merge Dependabot PRs
+
+on:
+  schedule:
+    # Run daily at 04:00 UTC since dependabot runs at 03:00 UTC
+    - cron: '0 4 * * *'
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# This workflow uses a GitHub App token to approve and merge Dependabot PRs
+# The token is created using the `actions/create-github-app-token` action
+# The token is used so that the updates are made by the GitHub App instead of Github Actions 
+# and will show up as such in the PR comments and history
+# In addition, the token is scoped to only the permissions needed for this workflow
+# see https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow for details
+
+jobs:
+  auto-merge-dependabot:
+    runs-on: ubuntu-latest
+    steps:
+
+      # Gets the GitHub App token
+      - uses: actions/create-github-app-token@v2
+        id: get-app-token
+        with:
+          # required
+          app-id: ${{ secrets.DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_APP_KEY }}
+          permission-pull-requests: write
+          permission-contents: write
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          persist-credentials: false
+      
+      - name: Setup GitHub CLI
+        run: |
+          # GitHub CLI is pre-installed on GitHub-hosted runners
+          gh --version
+      
+      - name: Run auto approve script
+        env:
+          GITHUB_TOKEN: ${{ steps.get-app-token.outputs.token }}
+        run: ./src/scripts/auto-approve-dependabot.sh ${{ github.repository }}

--- a/src/scripts/auto-approve-dependabot.sh
+++ b/src/scripts/auto-approve-dependabot.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# This script checks for open PRs from dependabot that have all checks passing and have not been
+# modified by another user, and approves+merges them automatically.
+# To be run as a GitHub action.
+
+# Check if repository argument is provided
+if [ -z "$1" ]; then
+    echo "Error: Repository name not provided."
+    echo "Usage: $0 <owner/repo>"
+    echo "Example: $0 hyperlight-dev/hyperlight"
+    exit 1
+fi
+
+REPO="$1"
+echo "Checking for open Dependabot PRs to approve and merge in $REPO..."
+
+# Get all open PRs from dependabot
+dependabot_prs=$(gh pr list -R "$REPO" --author "dependabot[bot]" --state open --json number,title,reviews)
+
+# Exit early if no PRs found
+if [ -z "$dependabot_prs" ] || [ "$dependabot_prs" = "[]" ]; then
+    echo "No open Dependabot PRs found in $REPO"
+    exit 0
+fi
+
+# Count how many PRs we found
+pr_count=$(echo "$dependabot_prs" | jq 'length')
+echo "Found $pr_count open Dependabot PRs in $REPO"
+
+# Process each PR
+echo "$dependabot_prs" | jq -c '.[]' | while read -r pr; do
+    pr_number=$(echo "$pr" | jq -r '.number')
+    pr_title=$(echo "$pr" | jq -r '.title')
+    
+    echo "Processing PR #$pr_number: $pr_title"
+    
+    # Check if PR only modifies allowed files
+    pr_files=$(gh pr view "$pr_number" -R "$REPO" --json files)
+    invalid_files=$(echo "$pr_files" | jq -r '.files[].path' | grep -v -E '(Cargo\.toml|Cargo\.lock|\.github/workflows/.+)' || true)
+    
+    if [ -n "$invalid_files" ]; then
+        echo "  ❌ PR #$pr_number modifies files that are not allowed for auto-merge:"
+        echo ${invalid_files/#/    - }
+        echo "  ℹ️ Only changes to Cargo.toml, Cargo.lock, or .github/workflows/ files are allowed"
+        continue
+    fi
+    
+    echo "  ✅ PR #$pr_number only modifies allowed files (Cargo.toml, Cargo.lock, or .github/workflows/)"
+    
+    # First, get detailed PR information including all checks
+    pr_details=$(gh pr view "$pr_number" -R "$REPO" --json statusCheckRollup,state)
+    
+    # Check if all status checks have passed (regardless of required or not)
+    all_checks_pass=true
+    has_pending_checks=false
+    failed_checks=""
+    
+    # First identify checks that are still in progress
+    pending_checks=$(echo "$pr_details" | jq -r '.statusCheckRollup[] | select(.status == "IN_PROGRESS" or .status == "QUEUED" or .status == "PENDING") | .name')
+    
+    if [ -n "$pending_checks" ]; then
+        echo "  ⏳ PR #$pr_number has pending checks:"
+        echo "$pending_checks" | sed 's/^/    - /'
+        echo "  ℹ️ We will still approve the PR so it can merge automatically once all checks pass"
+        has_pending_checks=true
+    fi
+    
+    # Check for failed checks - only include checks that have a conclusion and are not still running
+    # Explicitly exclude checks with status IN_PROGRESS, QUEUED, or PENDING
+    failed_checks=$(echo "$pr_details" | jq -r '.statusCheckRollup[] | 
+        select(.conclusion != null and 
+               .conclusion != "SUCCESS" and 
+               .conclusion != "NEUTRAL" and 
+               .conclusion != "SKIPPED" and
+               .status != "IN_PROGRESS" and 
+               .status != "QUEUED" and 
+               .status != "PENDING") | .name')
+    
+    if [ -n "$failed_checks" ]; then
+        echo "  ❌ PR #$pr_number has failed checks:"
+        echo "$failed_checks" | sed 's/^/    - /'
+        all_checks_pass=false
+        continue
+    fi
+    
+    # If we've reached here, either all checks have passed or some are pending
+    if [ "$has_pending_checks" = false ]; then
+        echo "  ✅ All status checks passed for PR #$pr_number"
+    fi
+    
+    # Check if PR has been modified by someone other than dependabot
+    pr_commits=$(gh pr view "$pr_number" -R "$REPO" --json commits)
+    non_dependabot_authors=$(echo "$pr_commits" | jq -r '.commits[].authors[].login' | grep -v -e "dependabot\[bot\]" -e "^$" || true)
+    
+    if [ -n "$non_dependabot_authors" ]; then
+        echo "  ❌ PR #$pr_number has been modified by users other than dependabot: $non_dependabot_authors"
+        continue
+    fi
+    
+    # Check if PR needs approval (i.e., hasn't been approved already)
+    already_approved=$(echo "$pr" | jq -r '.reviews[] | select(.state == "APPROVED") | .state' | grep -c "APPROVED" || true)
+    
+    if [ "$already_approved" -eq 0 ]; then
+        echo "  ✅ Approving PR #$pr_number"
+        gh pr review "$pr_number" -R "$REPO" --approve -b "Automatically approved by dependabot auto-approve workflow"
+    else
+        echo "  ℹ️ PR #$pr_number is already approved"
+    fi
+    
+    if [ "$has_pending_checks" = true ] || [ "$all_checks_pass" = true ]; then
+        # Check if PR is up-to-date with base branch
+        merge_status=$(gh pr view "$pr_number" -R "$REPO" --json mergeStateStatus -q '.mergeStateStatus')
+        
+        if [ "$merge_status" != "CLEAN" ]; then
+            echo "  ⚠️ PR #$pr_number is not up to date (status: $merge_status)"
+        else
+            echo "  ✅ PR #$pr_number is up to date with base branch"
+        fi
+        
+        # Enable auto-merge with squash strategy
+        echo "  ✅ Enabling auto-merge (squash strategy) for PR #$pr_number"
+        gh pr merge "$pr_number" -R "$REPO" --auto --squash
+        echo "  ✅ Auto-merge enabled for PR #$pr_number"
+    fi
+    
+done
+
+echo "Finished processing Dependabot PRs for $REPO"


### PR DESCRIPTION
This PR automates the process of approval and merging of dependabot PRs and does it at a time when there should be less merging of "real" PRs taking place. 

It does the following:

Sets the dependabot job to run at 03:00 UTC daily.

Runs a new job at 04:00 UTC daily which checks for any open PRs, for any PR that all of the following conditions are true:

1. Authored by dependabot
2. That the PR only modifies Cargo.lock/Cargo.toml files or GH actions workflows.
3. No status checks have failed.
4. That no one other than dependabot has authored any commits in the PR

The job will then set auto approve squash property on the PR (dependabot commands are not used as they need to be issued by a real user). These changes are made by an app as this means that as they show up as [dependabot-pr-auto-approver](https://github.com/apps/dependabot-pr-auto-approver)) , additionally  the app token is limited to the permissions required by this job and cannot obtain any other permissions unless the app is updated.


