### PR TITLE
fix rustfmt error

### DIFF
--- a/src/hyperlight_wasm/examples/metrics/main.rs
+++ b/src/hyperlight_wasm/examples/metrics/main.rs
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::sync::{Arc, Mutex};
+
 use examples_common::get_wasm_module_path;
 use hyperlight_wasm::{ParameterValue, Result, ReturnType, SandboxBuilder};
-use std::sync::{Arc, Mutex};
 
 fn main() -> Result<()> {
     // Install prometheus metrics exporter.


### PR DESCRIPTION
The latest commit f951686 fails just by cloning and running `just build`.

## Summary

This PR fixes a formatting error detected by rustfmt in the file.

## Details

- Ran `just build` to ensure successed.
- Verified that the formatting check now passes without errors.

## Error details

```sh
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 09s
cp ./src/wasm_runtime/target/x86_64-unknown-none/debug/wasm_runtime ./x64/debug/wasm_runtime
cp ./src/wasm_runtime/target/x86_64-unknown-none/debug/wasm_runtime ./src/hyperlight_wasm/redist/debug/wasm_runtime
rustup toolchain install nightly -c rustfmt && cargo +nightly fmt -v --all -- --check
info: syncing channel updates for 'nightly-x86_64-unknown-linux-gnu'
info: latest update on 2025-05-10, rust version 1.89.0-nightly (dcecb9917 2025-05-09)
info: downloading component 'rustfmt'
info: downloading component 'rust-src'
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-docs'
info: downloading component 'rust-std'
info: downloading component 'rustc'
 76.1 MiB /  76.1 MiB (100 %)  45.2 MiB/s in  1s
info: removing previous version of component 'rustfmt'
info: removing previous version of component 'rust-src'
info: removing previous version of component 'cargo'
info: removing previous version of component 'clippy'
info: removing previous version of component 'rust-docs'
info: removing previous version of component 'rust-std'
info: removing previous version of component 'rustc'
info: installing component 'rustfmt'
info: installing component 'rust-src'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-docs'
 20.1 MiB /  20.1 MiB (100 %)  11.8 MiB/s in  1s
info: installing component 'rust-std'
 27.1 MiB /  27.1 MiB (100 %)  23.5 MiB/s in  1s
info: installing component 'rustc'
 76.1 MiB /  76.1 MiB (100 %)  24.3 MiB/s in  3s

  nightly-x86_64-unknown-linux-gnu updated - rustc 1.89.0-nightly (dcecb9917 2025-05-09) (from rustc 1.88.0-nightly (50aa04180 2025-05-08))

info: checking for self-update
[lib (2021)] "/hyperlight-wasm/src/examples_common/src/lib.rs"
[bench (2021)] "/hyperlight-wasm/src/hyperlight_wasm/benches/benchmarks.rs"
[custom-build (2021)] "/hyperlight-wasm/src/hyperlight_wasm/build.rs"
[example (2021)] "/hyperlight-wasm/src/hyperlight_wasm/examples/helloworld/main.rs"
[example (2021)] "/hyperlight-wasm/src/hyperlight_wasm/examples/hostfuncs/main.rs"
[example (2021)] "/hyperlight-wasm/src/hyperlight_wasm/examples/metrics/main.rs"
[example (2021)] "/hyperlight-wasm/src/hyperlight_wasm/examples/rust_wasm_examples/main.rs"
[lib (2021)] "/hyperlight-wasm/src/hyperlight_wasm/src/lib.rs"
[bin (2021)] "/hyperlight-wasm/src/hyperlight_wasm_aot/src/main.rs"
rustfmt --edition 2021 --check /hyperlight-wasm/src/examples_common/src/lib.rs /hyperlight-wasm/src/hyperlight_wasm/benches/benchmarks.rs /hyperlight-wasm/src/hyperlight_wasm/build.rs /hyperlight-wasm/src/hyperlight_wasm/examples/helloworld/main.rs /hyperlight-wasm/src/hyperlight_wasm/examples/hostfuncs/main.rs /hyperlight-wasm/src/hyperlight_wasm/examples/metrics/main.rs /hyperlight-wasm/src/hyperlight_wasm/examples/rust_wasm_examples/main.rs /hyperlight-wasm/src/hyperlight_wasm/src/lib.rs /hyperlight-wasm/src/hyperlight_wasm_aot/src/main.rs
Diff in /hyperlight-wasm/src/hyperlight_wasm/examples/metrics/main.rs:14:
 limitations under the License.
 */

+use std::sync::{Arc, Mutex};
+
 use examples_common::get_wasm_module_path;
 use hyperlight_wasm::{ParameterValue, Result, ReturnType, SandboxBuilder};
-use std::sync::{Arc, Mutex};

 fn main() -> Result<()> {
     // Install prometheus metrics exporter.
error: Recipe `fmt-check` failed on line 40 with exit code 1
```

## Motivation

To ensure the project remains in a proper state, it is advisable to conduct format checks and other continuous integration processes either within the CI pipeline or prior to pushing changes.