### PR TITLE
Remove deislabs references from dockerfile and scripts

### DIFF
--- a/.github/workflows/dep_build_wasm_examples.yml
+++ b/.github/workflows/dep_build_wasm_examples.yml
@@ -4,13 +4,17 @@
 name: Build Wasm Examples
 
 on:
+  workflow_dispatch: {}
   workflow_call:
     inputs:
-        docs_only:
-          description: Skip building if docs only
-          required: false
-          type: string
-          default: "false"
+      docs_only:
+        description: Skip building if docs only
+        required: false
+        type: string
+        default: "false"
+  schedule:
+    # Run at 1am UTC daily
+    - cron: '0 1 * * *'
 
 permissions:
   packages: write
@@ -18,7 +22,7 @@ permissions:
 
 jobs:
     build-wasm-examples:
-      if: ${{ inputs.docs_only == 'false' }}
+      if: ${{ inputs.docs_only == 'false' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
@@ -48,14 +52,13 @@ jobs:
           with:
             images: ${{ github.repository_owner }}/wasm-clang-builder
         - name: Build and push wasm-clang-builder
-        # depedabot does not have push access to update the wasm-clang-builder image
-          if: github.actor != 'dependabot[bot]'
+        # Only push if not from a fork, not from pull request, and not from dependabot
           uses: docker/build-push-action@v6
           with:
             context: src/wasmsamples
             file: src/wasmsamples/dockerfile
             load: true
-            push: true
+            push: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && github.actor != 'dependabot[bot]' }}
             build-args: |
               WASI_SDK_VERSION_FULL=20.0
               GCC_VERSION=12

--- a/src/hyperlight_wasm/scripts/build-wasm-examples.sh
+++ b/src/hyperlight_wasm/scripts/build-wasm-examples.sh
@@ -29,9 +29,9 @@ else
     echo This will take a while if it is the first time you are building the docker image.
     echo Log in ${OUTPUT_DIR}/dockerbuild.log
 
-    docker pull ghcr.io/deislabs/wasm-clang-builder:latest
+    docker pull ghcr.io/hyperlight-dev/wasm-clang-builder:latest
 
-    docker build --build-arg GCC_VERSION=12 --build-arg WASI_SDK_VERSION_FULL=20.0 --cache-from ghcr.io/deislabs/wasm-clang-builder:latest -t wasm-clang-builder:latest . 2> ${OUTPUT_DIR}/dockerbuild.log
+    docker build --build-arg GCC_VERSION=12 --build-arg WASI_SDK_VERSION_FULL=20.0 --cache-from ghcr.io/hyperlight-dev/wasm-clang-builder:latest -t wasm-clang-builder:latest . 2> ${OUTPUT_DIR}/dockerbuild.log
 
     for FILENAME in $(find . -name '*.c')
     do

--- a/src/wasmsamples/compile-wasm.bat
+++ b/src/wasmsamples/compile-wasm.bat
@@ -14,11 +14,11 @@ where docker || (
 	set "dockeroutput=$(wslpath '%~2')"
 )
 
-%dockercmd% pull ghcr.io/deislabs/wasm-clang-builder:latest
+%dockercmd% pull ghcr.io/hyperlight-dev/wasm-clang-builder:latest
 
 echo Building docker image that has Wasm sdk. Should be quick if no changes to docker image.
 echo Log in %2\dockerbuild.log
-%dockercmd% build --build-arg GCC_VERSION=12 --build-arg WASI_SDK_VERSION_FULL=20.0 --cache-from ghcr.io/deislabs/wasm-clang-builder:latest -t wasm-clang-builder:latest !dockerinput! 2> %2dockerbuild.log
+%dockercmd% build --build-arg GCC_VERSION=12 --build-arg WASI_SDK_VERSION_FULL=20.0 --cache-from ghcr.io/hyperlight-dev/wasm-clang-builder:latest -t wasm-clang-builder:latest !dockerinput! 2> %2dockerbuild.log
 
 echo Building Wasm files in %1 and output to %2
 for /R "%1" %%i in (*.c) do (

--- a/src/wasmsamples/dockerfile
+++ b/src/wasmsamples/dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 ENV DEBIAN_FRONTEND=noninteractive
-LABEL org.opencontainers.image.source=https://github.com/deislabs/hyperlight-wasm
+LABEL org.opencontainers.image.source=https://github.com/hyperlight-dev/hyperlight-wasm
 
 ARG GCC_VERSION=12
 


### PR DESCRIPTION
Remove deislabs references from dockerfile and scripts

Allowed dep_build_wasm_examples to be run on demand so we can force update of sample builder image, also only set push to true if the PR does not come from a fork (since we cannot push the package from a fork), finally add a schedule so that the image gets updated if there are changes. 