### PR TITLE
Fix benchmarks in mshv3

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Run Benchmarks
       run: |
-        just bench-ci dev release
+        just bench-ci dev release ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
       working-directory: ./src/hyperlight_wasm
 
     - name: Upload Benchmarks

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -39,6 +39,7 @@ jobs:
       with:
           rust-toolchain: "1.85.0"
     - name: Verify vendor.tar
+      if: ${{ contains(github.ref, 'refs/heads/release/') }}
       run: |
         mv ./src/hyperlight_wasm/vendor.tar ./vendor.tar
         just make-vendor-tar
@@ -48,6 +49,7 @@ jobs:
         fi
       shell: bash
     - name: Package hyperlight-wasm crate
+      if: ${{ contains(github.ref, 'refs/heads/release/') }}
       run: cargo package -p hyperlight-wasm
       shell: bash
     - name: Install minver_rs


### PR DESCRIPTION
benchmarks are failing in mshv3 since the binary is compiled with the mshv 0.2.1 crate.
This PR passes the correct feature so that we build with mshv 0.3.x.

As a bonus, it also fixes an issue where the pre-release on the main branch tries to handle an non-existing vendor.tar.