### PR TITLE
Do not install gh in CI

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -54,15 +54,6 @@ jobs:
 
     ### Benchmarks ###
 
-    # Install GH cli (needed for just bench-download)
-    - name: Install github-cli (Linux mariner)
-      if: runner.os == 'Linux' && matrix.hypervisor == 'mshv' || matrix.hypervisor == 'mshv3'
-      run: sudo dnf install gh -y
-
-    - name: Install github-cli (Linux ubuntu)
-      if: runner.os == 'Linux' && matrix.hypervisor == 'kvm'
-      run: sudo apt install gh -y
-
     - name: Fetch tags
       run: |
         git fetch --tags origin

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -115,14 +115,6 @@ jobs:
           Write-Host "msiexec exited with code $LASTEXITCCODE"
           if ($LASTEXITCODE -ne 0) { cat log.txt; exit 1 }
         shell: pwsh
-    
-      - name: Install github-cli (Linux mariner)
-        if: runner.os == 'Linux' && (matrix.hypervisor == 'mshv2' || matrix.hypervisor == 'mshv3')
-        run: sudo dnf install gh -y
-
-      - name: Install github-cli (Linux ubuntu)
-        if: runner.os == 'Linux' && matrix.hypervisor == 'kvm'
-        run: sudo apt install gh -y
 
       - name: Test Examples
         run: just examples-ci ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}


### PR DESCRIPTION
This pull request removes redundant steps for installing the GitHub CLI (`gh`) in multiple workflow files. The changes simplify the workflows by eliminating unnecessary installation commands.

Workflow simplifications:

* [`.github/workflows/Benchmarks.yml`](diffhunk://#diff-e1bdab08f26f9843a73399234e0abfec6026cb3005722cc17301587d80ea8ed5L57-L65): Removed conditional steps for installing `gh` based on the operating system and hypervisor type.
* [`.github/workflows/dep_rust.yml`](diffhunk://#diff-50760080aa361ee9c95d0ef592c52d28a12107afceb7c4e6468897cb7c0079c9L119-L126): Removed conditional steps for installing `gh` for Linux environments with different hypervisor configurations.