### PR TITLE
Use bash for archiving benchmarks

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -78,6 +78,7 @@ jobs:
       with:
         pattern: benchmarks_*
     - name: Archive benchmarks
+      shell: bash
       run: |
         for BENCHMARK in benchmarks_*; do
           tar -zcvf $BENCHMARK.tar.gz $BENCHMARK


### PR DESCRIPTION
This pull request updates the `.github/workflows/CreateRelease.yml` file to specify the shell type for a job that archives benchmark files. The change ensures the job runs using the `bash` shell for better compatibility and clarity.