### PR TITLE
Bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm-aot"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/src/hyperlight_wasm/Cargo.toml
+++ b/src/hyperlight_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperlight-wasm"
-version = "0.1.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Library that enables wasm modules and components to be run inside lightweight Virtual Machine backed Sandbox. It is built on top of Hyperlight."

--- a/src/hyperlight_wasm_aot/Cargo.toml
+++ b/src/hyperlight_wasm_aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperlight-wasm-aot"
-version = "0.1.0"
+version = "0.7.0"
 edition = "2024"
 
 [dependencies]

--- a/src/hyperlight_wasm_macro/Cargo.toml
+++ b/src/hyperlight_wasm_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperlight-wasm-macro"
-version = "0.1.0"
+version = "0.7.0"
 edition = "2024"
 description = """
 Procedural macros to generate Hyperlight Wasm host and guest bindings from component types

--- a/src/wasm_runtime/Cargo.toml
+++ b/src/wasm_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-runtime"
-version = "0.1.0"
+version = "0.7.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
This pull request updates the version numbers for multiple crates in the project to align them with the new release version `0.7.0`. These changes ensure consistency across the codebase.

Version updates across crates:

* [`src/hyperlight_wasm/Cargo.toml`](diffhunk://#diff-c5f05d6ca1cb5675c27d5583227da151ee66768d1dd250516ea17415789ff8c1L3-R3): Updated the version from `0.1.0` to `0.7.0`.
* [`src/hyperlight_wasm_aot/Cargo.toml`](diffhunk://#diff-4f0605fe2b7307285a20f28c6c5104192c6bc75df6e07d12347ba3062b97f141L3-R3): Updated the version from `0.1.0` to `0.7.0`.
* [`src/hyperlight_wasm_macro/Cargo.toml`](diffhunk://#diff-0d376b3508e6b7e4e9bfe862a0059cbcc47df3572b98aed205ec99a1ecb71b21L3-R3): Updated the version from `0.1.0` to `0.7.0`.
* [`src/wasm_runtime/Cargo.toml`](diffhunk://#diff-74514572bb85d0d1197d5a87f90004f8d00c2dd1281400a7592994001103530eL3-R3): Updated the version from `0.1.0` to `0.7.0`.