### PR TITLE
Add per sandbox configuration for crashdumps

### DIFF
--- a/src/hyperlight_wasm/src/sandbox/sandbox_builder.rs
+++ b/src/hyperlight_wasm/src/sandbox/sandbox_builder.rs
@@ -95,6 +95,15 @@ impl SandboxBuilder {
         self
     }
 
+    /// Enable or disable crashdump generation for the sandbox
+    /// When enabled, core dumps will be generated when the guest crashes
+    /// This requires the `crashdump` feature to be enabled
+    #[cfg(feature = "crashdump")]
+    pub fn with_crashdump_enabled(mut self, enabled: bool) -> Self {
+        self.config.set_guest_core_dump(enabled);
+        self
+    }
+
     /// Get the current configuration
     pub fn get_config(&self) -> &SandboxConfiguration {
         &self.config

--- a/src/wasm_runtime/Cargo.lock
+++ b/src/wasm_runtime/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm-macro"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "hyperlight-component-util",
  "itertools",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-runtime"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "cargo_metadata",
  "cc",


### PR DESCRIPTION
This pull request introduces a new method to the `SandboxBuilder` class for enabling or disabling crashdump generation in the sandbox. This functionality is gated behind the `crashdump` feature flag.

Key change:

* [`src/hyperlight_wasm/src/sandbox/sandbox_builder.rs`](diffhunk://#diff-e5f85d2968dd797236d382b4b6df3ca06d653a09e3f8265d33aac1bbab3ffc6fR98-R106): Added the `with_crashdump_enabled` method to allow toggling crashdump generation for the sandbox. This feature requires the `crashdump` feature flag to be enabled.

original PR in hyperlight: https://github.com/hyperlight-dev/hyperlight/pull/417

The cargo lock was also not fully updated.