### PR TITLE
Update to use the latest wasi sdk

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y g++-multilib \
     && apt-get install -y libgcc-${GCC_VERSION}-dev \
     && apt-get install -y lib32gcc-${GCC_VERSION}-dev 
 
-ARG WASI_SDK_VERSION_FULL=20.0
+ARG WASI_SDK_VERSION_FULL=25.0
 ARG WASI_SDK_VERSION_MAJOR=${WASI_SDK_VERSION_FULL%%.*}
 
 # Install wasi-sdk

--- a/.github/workflows/CreateDevcontainerImage.yml
+++ b/.github/workflows/CreateDevcontainerImage.yml
@@ -18,7 +18,7 @@ env:
   LLVM_VERSION: 17
   RUST_TOOLCHAIN_DEFAULT: 1.85.0
   RUST_TOOLCHAIN_FILE: rust-toolchain.toml
-  WASI_SDK_VERSION_FULL: "20.0"
+  WASI_SDK_VERSION_FULL: "25.0"
   GCC_VERSION: "12" 
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.

--- a/.github/workflows/dep_build_wasm_examples.yml
+++ b/.github/workflows/dep_build_wasm_examples.yml
@@ -71,7 +71,7 @@ jobs:
             load: true
             push: ${{ env.DO_PUSH }}
             build-args: |
-              WASI_SDK_VERSION_FULL=20.0
+              WASI_SDK_VERSION_FULL=25.0
               GCC_VERSION=12
             tags: ghcr.io/${{ github.repository_owner }}/wasm-clang-builder:latest
             cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wasm-clang-builder:buildcache

--- a/src/hyperlight_wasm/scripts/build-wasm-examples.sh
+++ b/src/hyperlight_wasm/scripts/build-wasm-examples.sh
@@ -31,7 +31,7 @@ else
 
     docker pull ghcr.io/hyperlight-dev/wasm-clang-builder:latest
 
-    docker build --build-arg GCC_VERSION=12 --build-arg WASI_SDK_VERSION_FULL=20.0 --cache-from ghcr.io/hyperlight-dev/wasm-clang-builder:latest -t wasm-clang-builder:latest . 2> ${OUTPUT_DIR}/dockerbuild.log
+    docker build --build-arg GCC_VERSION=12 --build-arg WASI_SDK_VERSION_FULL=25.0 --cache-from ghcr.io/hyperlight-dev/wasm-clang-builder:latest -t wasm-clang-builder:latest . 2> ${OUTPUT_DIR}/dockerbuild.log
 
     for FILENAME in $(find . -name '*.c')
     do

--- a/src/hyperlight_wasm_macro/Cargo.lock
+++ b/src/hyperlight_wasm_macro/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm-macro"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "hyperlight-component-util",
  "itertools",

--- a/src/wasm_runtime/src/wasip1.rs
+++ b/src/wasm_runtime/src/wasip1.rs
@@ -83,6 +83,13 @@ pub(crate) fn register_handlers<T: 'static>(linker: &mut Linker<T>) -> Result<()
     })?;
     linker.func_wrap(
         "wasi_snapshot_preview1",
+        "random_get",
+        |buff: i32, len: i32| -> i32 {
+            panic!("random_get called for {} with len {}", buff, len);
+        },
+    )?;
+    linker.func_wrap(
+        "wasi_snapshot_preview1",
         "fd_fdstat_get",
         |mut ctx: Caller<'_, T>, fd: i32, retptr: i32| {
             if fd != 1 {

--- a/src/wasmsamples/compile-wasm.bat
+++ b/src/wasmsamples/compile-wasm.bat
@@ -18,7 +18,7 @@ where docker || (
 
 echo Building docker image that has Wasm sdk. Should be quick if no changes to docker image.
 echo Log in %2\dockerbuild.log
-%dockercmd% build --build-arg GCC_VERSION=12 --build-arg WASI_SDK_VERSION_FULL=20.0 --cache-from ghcr.io/hyperlight-dev/wasm-clang-builder:latest -t wasm-clang-builder:latest !dockerinput! 2> %2dockerbuild.log
+%dockercmd% build --build-arg GCC_VERSION=12 --build-arg WASI_SDK_VERSION_FULL=25.0 --cache-from ghcr.io/hyperlight-dev/wasm-clang-builder:latest -t wasm-clang-builder:latest !dockerinput! 2> %2dockerbuild.log
 
 echo Building Wasm files in %1 and output to %2
 for /R "%1" %%i in (*.c) do (

--- a/src/wasmsamples/dockerfile
+++ b/src/wasmsamples/dockerfile
@@ -13,11 +13,11 @@ RUN apt-get install -y  wget  \
  && apt-get install -y libgcc-${GCC_VERSION}-dev \
  && apt-get install -y lib32gcc-${GCC_VERSION}-dev 
 
-ARG WASI_SDK_VERSION_FULL=20.0
+ARG WASI_SDK_VERSION_FULL=25.0
 ARG WASI_SDK_VERSION_MAJOR=${WASI_SDK_VERSION_FULL%%.*}
 
-RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION_MAJOR}/wasi-sdk-${WASI_SDK_VERSION_FULL}-linux.tar.gz \
- && tar xvf wasi-sdk-${WASI_SDK_VERSION_FULL}-linux.tar.gz \
- && rm wasi-sdk-${WASI_SDK_VERSION_FULL}-linux.tar.gz \
- && mv /wasi-sdk-${WASI_SDK_VERSION_FULL} /opt/wasi-sdk
+RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION_MAJOR}/wasi-sdk-${WASI_SDK_VERSION_FULL}-x86_64-linux.tar.gz \
+ && tar xvf wasi-sdk-${WASI_SDK_VERSION_FULL}-x86_64-linux.tar.gz \
+ && rm wasi-sdk-${WASI_SDK_VERSION_FULL}-x86_64-linux.tar.gz \
+ && mv /wasi-sdk-${WASI_SDK_VERSION_FULL}-x86_64-linux /opt/wasi-sdk
 CMD ["/bin/sh"]


### PR DESCRIPTION
This updates the project to use the latest wasi-sdk.  

Between wasi-sdk 23 and wasi-sdk 24 there was a change that brought in a dependency on `wasi_snapshot_preview1::random_get`.  So this adds it so the projects run. 

I didn't see any obvious change set that brought this in but here is the diff:

https://github.com/WebAssembly/wasi-sdk/compare/wasi-sdk-23...wasi-sdk-24

Instead of just throwing, we could also implement random_get like [wasmtime does](https://github.com/bytecodealliance/wasmtime/blob/2d95076dd3f987e15fa76e1cedd71cc2c6f91220/crates/wasi/src/preview1.rs#L2558).  