### PR TITLE
Add zerocopy mapping for wasm binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-util-schemas"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.69",
+ "toml 0.8.23",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,19 +701,6 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1249,8 +1252,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-common"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b9232222e023b84c7c10bdb67327f503567a1a5ff68db935683af0147d73ba"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=ea6fa8f#ea6fa8f16dae2325d94af39eb6ac3b441b24dcac"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -1262,8 +1264,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-component-macro"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc0fc7f0d77ab2c16277da4efb58fa99c56f607f9407fd5c0490909c327facd"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=ea6fa8f#ea6fa8f16dae2325d94af39eb6ac3b441b24dcac"
 dependencies = [
  "env_logger",
  "hyperlight-component-util",
@@ -1278,8 +1279,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-component-util"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88137b20c4761f4b309d36b22574e2283745afad5959df7ecc5928557417d098"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=ea6fa8f#ea6fa8f16dae2325d94af39eb6ac3b441b24dcac"
 dependencies = [
  "itertools 0.14.0",
  "log",
@@ -1293,15 +1293,13 @@ dependencies = [
 [[package]]
 name = "hyperlight-host"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb5d2db5c1325df0c1042680ccbff16958105a2842140736ac463d67df89fba"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=ea6fa8f#ea6fa8f16dae2325d94af39eb6ac3b441b24dcac"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "chrono",
- "crossbeam",
  "crossbeam-channel",
  "elfcore",
  "flatbuffers",
@@ -1331,7 +1329,7 @@ dependencies = [
  "vmm-sys-util",
  "windows",
  "windows-result",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "windows-version",
 ]
 
@@ -1358,7 +1356,7 @@ dependencies = [
  "once_cell",
  "page_size",
  "tar",
- "toml",
+ "toml 0.9.0",
  "tracing",
  "windows",
 ]
@@ -2622,6 +2620,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
@@ -2877,17 +2884,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f271e09bde39ab52250160a67e88577e0559ad77e9085de6e9051a2c4353f8f8"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2900,6 +2928,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,6 +2949,12 @@ checksum = "b5c1c469eda89749d2230d8156a5969a69ffe0d6d01200581cdc6110674d293e"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3747,6 +3795,9 @@ name = "winnow"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ repository = "https://github.com/hyperlight-dev/hyperlight-wasm"
 readme = "README.md"
 
 [workspace.dependencies]
-hyperlight-host = { version = "0.7.0", default-features = false, features = ["executable_heap", "init-paging"] }
+hyperlight-host = { version = "0.7.0", git = "https://github.com/hyperlight-dev/hyperlight", rev = "ea6fa8f", default-features = false, features = ["executable_heap", "init-paging"] }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727634051,
+        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-mozilla": {
+      "locked": {
+        "lastModified": 1704373101,
+        "narHash": "sha256-+gi59LRWRQmwROrmE1E2b3mtocwueCQqZ60CwLG+gbg=",
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "rev": "9b11a87c0cc54e308fa83aac5b4ee1816d5418a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mozilla",
+        "ref": "master",
+        "repo": "nixpkgs-mozilla",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-mozilla": "nixpkgs-mozilla"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,83 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs-mozilla.url = "github:mozilla/nixpkgs-mozilla/master";
+  outputs = { self, nixpkgs, nixpkgs-mozilla, ... } @ inputs: 
+let token = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IktRMnRBY3JFN2xCYVZWR0JtYzVGb2JnZEpvNCIsImtpZCI6IktRMnRBY3JFN2xCYVZWR0JtYzVGb2JnZEpvNCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNzIyODc3MzM2LCJuYmYiOjE3MjI4NzczMzYsImV4cCI6MTcyMjg4MjAyOCwiX2NsYWltX25hbWVzIjp7Imdyb3VwcyI6InNyYzEifSwiX2NsYWltX3NvdXJjZXMiOnsic3JjMSI6eyJlbmRwb2ludCI6Imh0dHBzOi8vZ3JhcGgud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3L3VzZXJzLzFkNDgzMWMxLWVhYTgtNGY2OS1hZTVjLTE4MTQwMjBlZTJlYy9nZXRNZW1iZXJPYmplY3RzIn19LCJhY3IiOiIxIiwiYWlvIjoiQVZRQXEvOFhBQUFBK3V0TC9hdXdsU1ppQXp1T1pjdk14aERWay9lTlJaR0tiSFNOTjZXcS9VRTlRZGJTOEdmeWFadDUyM2dsT3FOZVdDckVkQ2E1RFV5c2lHcTdJK1ZMTzJoYW9UVzJ6MFhzVm1VTEMwK1RHUGs9IiwiYW1yIjpbInB3ZCIsInJzYSIsIm1mYSJdLCJhcHBpZCI6IjA0YjA3Nzk1LThkZGItNDYxYS1iYmVlLTAyZjllMWJmN2I0NiIsImFwcGlkYWNyIjoiMCIsImNhcG9saWRzX2xhdGViaW5kIjpbIjI5Mzk5Y2Y5LTliNmItNDIwNS1iNWIzLTEzYTEzNGU5YjIzMyJdLCJkZXZpY2VpZCI6IjVmZThlYWYzLTYzYWUtNGY3Ny1hMDkxLTI4MzcxZTRlZmRlMyIsImZhbWlseV9uYW1lIjoiTWVub24iLCJnaXZlbl9uYW1lIjoiTHVjeSIsImlkdHlwIjoidXNlciIsImlwYWRkciI6IjkyLjQwLjE3MC4yMjAiLCJuYW1lIjoiTHVjeSBNZW5vbiIsIm9pZCI6IjFkNDgzMWMxLWVhYTgtNGY2OS1hZTVjLTE4MTQwMjBlZTJlYyIsIm9ucHJlbV9zaWQiOiJTLTEtNS0yMS0yMTI3NTIxMTg0LTE2MDQwMTI5MjAtMTg4NzkyNzUyNy03ODMzODE4MyIsInB1aWQiOiIxMDAzMjAwM0FBNkI0MTNFIiwicmgiOiIwLkFSb0F2NGo1Y3ZHR3IwR1JxeTE4MEJIYlIwWklmM2tBdXRkUHVrUGF3ZmoyTUJNYUFIUS4iLCJzY3AiOiJ1c2VyX2ltcGVyc29uYXRpb24iLCJzdWIiOiJ0bmo3a0hTb1ZIM3V6eGVsYkVfNnRFSEVoaDRBaWVtTGZ4aThDNld1NzBvIiwidGlkIjoiNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3IiwidW5pcXVlX25hbWUiOiJtZW5vbmx1Y3lAbWljcm9zb2Z0LmNvbSIsInVwbiI6Im1lbm9ubHVjeUBtaWNyb3NvZnQuY29tIiwidXRpIjoiaFRXM0lFVmtCRXVaWFRTSnoxNW1BQSIsInZlciI6IjEuMCIsIndpZHMiOlsiYjc5ZmJmNGQtM2VmOS00Njg5LTgxNDMtNzZiMTk0ZTg1NTA5Il0sInhtc19jYWUiOiIxIiwieG1zX2NjIjpbIkNQMSJdLCJ4bXNfZmlsdGVyX2luZGV4IjpbIjI2Il0sInhtc19pZHJlbCI6IjI2IDEiLCJ4bXNfcmQiOiIwLjQyTGxZQlJpbEFJQSIsInhtc19zc20iOiIxIiwieG1zX3RjZHQiOjEyODkyNDE1NDd9.t5d56DG8TDlkLYJPIVHFcftn4PbrPOhzwIQoyJRqe4s1VVgscqhNQH4PYqPjizkHy76lZM0cI6a3lrRfVbr1wXBDk82jLyxQ_AXR0yMN4RmrrTRK5M5p5sKHtXq85rTohHl2RSeu7VsWNNBVMsy1Efh6UN095zFZvzntbn-N2JXjloprrz5JcHb1hasT9-o_tsebIM2jefbj7ggpuiGRcbYM3i5mgLVGd19gYzlpAq7YyiE-SvHtLu3cSSms4KwDeoi3QpZiV_5ok1dsZxaonGplaqXeE_pRM92JCvk1paahCKNmrOjZPcJ4hXUlH4q7OY2Hm6MY4GKcTG_xXXoWaQ"; in
+{
+    devShells.x86_64-linux.default = with import nixpkgs { system = "x86_64-linux"; overlays = [ (import (nixpkgs-mozilla + "/rust-overlay.nix")) ]; }; let
+      stable = rustChannelOf {
+        date = "2025-02-20";
+        channel = "stable";
+        sha256 = "sha256-AJ6LX/Q/Er9kS15bn9iflkUwcgYqRQxiOIL2ToVAXaU=";
+      };
+      nightly = rustChannelOf {
+        date = "2025-06-04";
+        channel = "nightly";
+        sha256 = "sha256-eFuFA5spScrde7b7lSV5QAND1m0+Ds6gbVODfDE3scg=";
+      };
+      rust_stable = stable.rust.override {
+        targets = [ "x86_64-unknown-linux-gnu" "x86_64-pc-windows-msvc" "x86_64-unknown-none" "wasm32-wasip1" "wasm32-unknown-unknown" ];
+      };
+      rust_nightly = nightly.rust.override {
+        targets = [ "x86_64-unknown-linux-gnu" "x86_64-pc-windows-msvc" "x86_64-unknown-none" "wasm32-wasip1" "wasm32-unknown-unknown" ];
+      };
+      rust-platform = makeRustPlatform {
+        cargo = rust_stable;
+        rustc = rust_stable;
+      };
+    in ((rust-platform.buildRustPackage.override { stdenv = clangStdenv; }) rec {
+      pname = "hyperlight";
+      version = "0.0.0";
+      src = lib.cleanSource ./.;
+      #cargoHash = lib.fakeHash;
+      #cargoHash = "sha256-Z4dkYH1BBSUpqiHETkIi+i13FD1q5CyB0NuGHUxhLm0=";
+      cargoHash = "sha256-CsHcz91S5NHdoHgQVLFizyd5rUXMlMDHEN67JrQ6Xls=";
+      nativeBuildInputs = [
+        azure-cli
+        just
+        dotnet-sdk_6
+        clang
+        llvmPackages_18.llvm
+        gh
+        lld
+        valgrind
+        pkg-config
+        ffmpeg
+        mkvtoolnix
+        wasm-tools
+        nodejs # todo - just for now
+        cargo-component
+        wasm-tools
+      ];
+      buildInputs = [
+        pango
+        cairo
+        openssl
+      ];
+      auditable = false;
+      depsExtraArgs = {
+        CARGO_REGISTRIES_HYPERLIGHT_REDIST_TOKEN = token;
+        CARGO_REGISTRIES_HYPERLIGHT_PACKAGES_TOKEN = token;
+      };
+      KVM_SHOULD_BE_PRESENT = "true";
+      LIBCLANG_PATH = "${pkgs.llvmPackages_18.libclang.lib}/lib";
+      RUST_NIGHTLY = "${rust_nightly}";
+      shellHook = ''
+        rustc_nightly() {
+          (export PATH="${rust_nightly}/bin/:$PATH"; ${rust_nightly}/bin/rustc "$@")
+        }
+        rustc_stable() {
+          (export PATH="${rust_stable}/bin/:$PATH"; ${rust_stable}/bin/rustc "$@")
+        }
+        cargo_nightly() {
+          (export PATH="${rust_nightly}/bin/:$PATH"; ${rust_nightly}/bin/cargo "$@")
+        }
+        cargo_stable() {
+          (export PATH="${rust_stable}/bin/:$PATH"; ${rust_stable}/bin/cargo "$@")
+        }
+      '';
+    }).overrideAttrs(oA: {
+      hardeningDisable = [ "all" ];
+    });
+  };
+}

--- a/src/hyperlight_wasm/Cargo.toml
+++ b/src/hyperlight_wasm/Cargo.toml
@@ -58,7 +58,7 @@ windows = { version = "0.61", features = ["Win32_System_Threading"] }
 page_size = "0.6.0"
 
 [dev-dependencies]
-hyperlight-component-macro = "0.7.0"
+hyperlight-component-macro = { version = "0.7.0", git = "https://github.com/hyperlight-dev/hyperlight", rev = "ea6fa8f" }
 examples_common = { path = "../examples_common" }
 criterion = { version = "0.6.0", features = ["html_reports"] }
 crossbeam-queue = "0.3"

--- a/src/hyperlight_wasm_aot/src/main.rs
+++ b/src/hyperlight_wasm_aot/src/main.rs
@@ -150,9 +150,5 @@ fn main() {
 fn get_config() -> Config {
     let mut config = Config::new();
     config.target("x86_64-unknown-none").unwrap();
-    config.memory_reservation(0);
-    config.memory_reservation_for_growth(0);
-    config.memory_guard_size(0);
-    config.guard_before_linear_memory(false);
     config
 }

--- a/src/hyperlight_wasm_macro/Cargo.lock
+++ b/src/hyperlight_wasm_macro/Cargo.lock
@@ -39,8 +39,6 @@ dependencies = [
 [[package]]
 name = "hyperlight-component-util"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88137b20c4761f4b309d36b22574e2283745afad5959df7ecc5928557417d098"
 dependencies = [
  "itertools",
  "log",

--- a/src/hyperlight_wasm_macro/Cargo.toml
+++ b/src/hyperlight_wasm_macro/Cargo.toml
@@ -17,4 +17,4 @@ proc-macro2 = { version = "1.0.93" }
 syn = { version = "2.0.96" }
 itertools = { version = "0.14.0" }
 prettyplease = { version = "0.2.31" }
-hyperlight-component-util = { version = "0.7.0" }
+hyperlight-component-util = { version = "0.7.0", git = "https://github.com/hyperlight-dev/hyperlight", rev = "ea6fa8f" }

--- a/src/wasm_runtime/Cargo.lock
+++ b/src/wasm_runtime/Cargo.lock
@@ -601,8 +601,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-common"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b9232222e023b84c7c10bdb67327f503567a1a5ff68db935683af0147d73ba"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=ea6fa8f#ea6fa8f16dae2325d94af39eb6ac3b441b24dcac"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -613,8 +612,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-component-util"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88137b20c4761f4b309d36b22574e2283745afad5959df7ecc5928557417d098"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=ea6fa8f#ea6fa8f16dae2325d94af39eb6ac3b441b24dcac"
 dependencies = [
  "itertools",
  "log",
@@ -628,8 +626,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9f007acee89f791a645acd7ae517190bd2bd2e4e24ede531e8d9b70c898c65"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=ea6fa8f#ea6fa8f16dae2325d94af39eb6ac3b441b24dcac"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -639,8 +636,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-guest-bin"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e125eb8b36a7f8909c8efea4e37ebb5306307fc3e20a0d2b533a40441785e34"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=ea6fa8f#ea6fa8f16dae2325d94af39eb6ac3b441b24dcac"
 dependencies = [
  "buddy_system_allocator",
  "cc",

--- a/src/wasm_runtime/Cargo.toml
+++ b/src/wasm_runtime/Cargo.toml
@@ -11,9 +11,9 @@ doctest = false
 bench = false
 
 [dependencies]
-hyperlight-common = { version = "0.7.0", default-features = false }
-hyperlight-guest-bin = { version = "0.7.0", features = [ "printf" ] }
-hyperlight-guest = { version = "0.7.0" }
+hyperlight-common = { version = "0.7.0", git = "https://github.com/hyperlight-dev/hyperlight", rev = "ea6fa8f", default-features = false }
+hyperlight-guest-bin = { version = "0.7.0", git = "https://github.com/hyperlight-dev/hyperlight", rev = "ea6fa8f", features = [ "printf" ] }
+hyperlight-guest = { version = "0.7.0", git = "https://github.com/hyperlight-dev/hyperlight", rev = "ea6fa8f" }
 wasmtime = { version = "34.0.1", default-features = false, features = [ "runtime", "custom-virtual-memory", "custom-native-signals", "component-model" ] }
 hyperlight-wasm-macro = { path = "../hyperlight_wasm_macro" }
 spin = "0.9.8"

--- a/src/wasm_runtime/src/component.rs
+++ b/src/wasm_runtime/src/component.rs
@@ -33,6 +33,8 @@ use spin::Mutex;
 use wasmtime::component::{Component, Instance, Linker};
 use wasmtime::{Config, Engine, Store};
 
+use crate::platform;
+
 static CUR_ENGINE: Mutex<Option<Engine>> = Mutex::new(None);
 static CUR_LINKER: Mutex<Option<Linker<()>>> = Mutex::new(None);
 static CUR_STORE: Mutex<Option<Store<()>>> = Mutex::new(None);
@@ -74,6 +76,8 @@ fn load_wasm_module(function_call: &FunctionCall) -> Result<Vec<u8>> {
 
 #[no_mangle]
 pub extern "C" fn hyperlight_main() {
+    platform::register_page_fault_handler();
+
     let mut config = Config::new();
     config.memory_reservation(0);
     config.memory_guard_size(0);

--- a/src/wasm_runtime/src/component.rs
+++ b/src/wasm_runtime/src/component.rs
@@ -102,10 +102,6 @@ pub extern "C" fn hyperlight_main() {
     platform::register_page_fault_handler();
 
     let mut config = Config::new();
-    config.memory_reservation(0);
-    config.memory_guard_size(0);
-    config.memory_reservation_for_growth(0);
-    config.guard_before_linear_memory(false);
     config.with_custom_code_memory(Some(alloc::sync::Arc::new(platform::WasmtimeCodeMemory {})));
     let engine = Engine::new(&config).unwrap();
     let linker = Linker::new(&engine);

--- a/src/wasm_runtime/src/module.rs
+++ b/src/wasm_runtime/src/module.rs
@@ -32,7 +32,7 @@ use hyperlight_guest_bin::host_comm::print_output_with_host_print;
 use spin::Mutex;
 use wasmtime::{Config, Engine, Linker, Module, Store, Val};
 
-use crate::{hostfuncs, marshal, wasip1};
+use crate::{hostfuncs, marshal, platform, wasip1};
 
 static CUR_ENGINE: Mutex<Option<Engine>> = Mutex::new(None);
 static CUR_LINKER: Mutex<Option<Linker<()>>> = Mutex::new(None);
@@ -141,6 +141,8 @@ fn load_wasm_module(function_call: &FunctionCall) -> Result<Vec<u8>> {
 #[no_mangle]
 #[allow(clippy::fn_to_numeric_cast)] // GuestFunctionDefinition expects a function pointer as i64
 pub extern "C" fn hyperlight_main() {
+    platform::register_page_fault_handler();
+
     register_function(GuestFunctionDefinition::new(
         "PrintOutput".to_string(),
         vec![ParameterType::String],

--- a/src/wasm_runtime/src/module.rs
+++ b/src/wasm_runtime/src/module.rs
@@ -89,10 +89,6 @@ pub fn guest_dispatch_function(function_call: &FunctionCall) -> Result<Vec<u8>> 
 
 fn init_wasm_runtime() -> Result<Vec<u8>> {
     let mut config = Config::new();
-    config.memory_reservation(0);
-    config.memory_guard_size(0);
-    config.memory_reservation_for_growth(0);
-    config.guard_before_linear_memory(false);
     config.with_custom_code_memory(Some(alloc::sync::Arc::new(platform::WasmtimeCodeMemory {})));
     let engine = Engine::new(&config)?;
     let mut linker = Linker::new(&engine);


### PR DESCRIPTION
This predominantly adds support for using the features from hyperlight-dev/hyperlight#696 to zerocopy map a wasm binary into the guest.  Since this requires being able to modify guest page tables anyway, it also does the first pieces of setting up virtual memory in wasmtime, enough to get a view towards performance/etc.  There is a major missing piece in that wasmtime_mprotect is not properly implemented, which means that wasm can escape to the guest relatively easily; I will make an issue to track getting that fixed.