### PR TITLE
Use the branch name to create the release

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -57,18 +57,13 @@ jobs:
       if: ${{ contains(github.ref, 'refs/heads/release/') }}
       run: cargo package -p hyperlight-wasm
       shell: bash
-    - name: Install minver_rs
-      run: |
-          cargo install minver_rs
-      shell: bash
     - name: Set HYPERLIGHTWASM_VERSION
       run: |
-        git fetch --tags || true
-        export MINVER_TAG_PREFIX="v"
-        export MINVER_AUTO_INCREMENT_LEVEL="Minor"
-        export MINVER_PRERELEASE_IDENTIFIER="preview"
-        echo "HYPERLIGHTWASM_VERSION=$(minver)" >> $GITHUB_ENV
-        echo "HYPERLIGHTWASM_VERSION=$(minver)"
+        git fetch --tags
+        version=$(echo "${{ github.ref }}" | sed -E 's#refs/heads/release/v##')
+        echo "HYPERLIGHTWASM_VERSION=$version" >> $GITHUB_ENV
+        echo "HYPERLIGHTWASM_VERSION=$version"
+      if: ${{ contains(github.ref, 'refs/heads/release/') }}
       shell: bash
     - name: Download Wasm Modules
       uses: actions/download-artifact@v4


### PR DESCRIPTION
The previous step created a release on the wrong tag and version: https://github.com/hyperlight-dev/hyperlight-wasm/releases/tag/v0.8.0-preview.1. I've manually updated the release to reflect the correct tag but this will make it automated in the next release.

This updates the step to do the same thing the hyperlight repo does so we can follow the same [process](https://github.com/hyperlight-dev/hyperlight/blob/main/docs/how-to-make-releases.md) in this repo: https://github.com/hyperlight-dev/hyperlight/blob/39df600cbaf5a9a74215879f67207d1d07dc3d54/.github/workflows/CreateRelease.yml#L110-L117