### PR TITLE
Remove aot acting as wasm

### DIFF
--- a/.github/workflows/dep_build_wasm_examples.yml
+++ b/.github/workflows/dep_build_wasm_examples.yml
@@ -87,5 +87,4 @@ jobs:
           with:
             name: guest-modules
             path: | 
-              x64/release/*.wasm
               x64/release/*.aot

--- a/Justfile
+++ b/Justfile
@@ -42,7 +42,6 @@ build-rust-wasm-examples target=default-target: (mkdir-redist target)
     rustup target add wasm32-unknown-unknown
     cd ./src/rust_wasm_samples && cargo build --target wasm32-unknown-unknown --profile={{ if target == "debug" {"dev"} else { target } }}
     cargo run -p hyperlight-wasm-aot compile ./src/rust_wasm_samples/target/wasm32-unknown-unknown/{{ target }}/rust_wasm_samples.wasm ./x64/{{ target }}/rust_wasm_samples.aot
-    cp ./x64/{{ target }}/rust_wasm_samples.aot ./x64/{{ target }}/rust_wasm_samples.wasm
 
 build-rust-component-examples target=default-target: (compile-wit)
     # use cargo component so we don't get all the wasi imports https://github.com/bytecodealliance/cargo-component?tab=readme-ov-file#relationship-with-wasm32-wasip2
@@ -50,7 +49,6 @@ build-rust-component-examples target=default-target: (compile-wit)
     rustup target add wasm32-unknown-unknown
     cd ./src/component_sample && cargo component build --target wasm32-unknown-unknown --profile={{ if target == "debug" {"dev"} else { target } }}
     cargo run -p hyperlight-wasm-aot compile --component ./src/component_sample/target/wasm32-unknown-unknown/{{ target }}/component_sample.wasm ./x64/{{ target }}/component_sample.aot
-    cp ./x64/{{ target }}/component_sample.aot ./x64/{{ target }}/component_sample.wasm
 
 check target=default-target:
     cargo check --profile={{ if target == "debug" {"dev"} else { target } }}

--- a/src/hyperlight_wasm/benches/benchmarks.rs
+++ b/src/hyperlight_wasm/benches/benchmarks.rs
@@ -28,8 +28,8 @@ fn get_time_since_boot_microsecond() -> Result<i64> {
 fn wasm_guest_call_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("wasm_guest_functions");
 
-    let bench_guest_function = |b: &mut Bencher<'_>, ext| {
-        let mut loaded_wasm_sandbox = get_loaded_wasm_sandbox(ext);
+    let bench_guest_function = |b: &mut Bencher<'_>| {
+        let mut loaded_wasm_sandbox = get_loaded_wasm_sandbox();
 
         b.iter(|| {
             loaded_wasm_sandbox
@@ -38,12 +38,8 @@ fn wasm_guest_call_benchmark(c: &mut Criterion) {
         });
     };
 
-    group.bench_function("wasm_guest_call", |b: &mut Bencher<'_>| {
-        bench_guest_function(b, "wasm");
-    });
-
     group.bench_function("wasm_guest_call_aot", |b: &mut Bencher<'_>| {
-        bench_guest_function(b, "aot");
+        bench_guest_function(b);
     });
 
     group.finish();
@@ -52,7 +48,7 @@ fn wasm_guest_call_benchmark(c: &mut Criterion) {
 fn wasm_sandbox_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("wasm_sandboxes");
     let create_wasm_sandbox = || {
-        get_loaded_wasm_sandbox("wasm");
+        get_loaded_wasm_sandbox();
     };
 
     group.bench_function("create_sandbox", |b| {
@@ -66,7 +62,7 @@ fn wasm_sandbox_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-fn get_loaded_wasm_sandbox(ext: &str) -> LoadedWasmSandbox {
+fn get_loaded_wasm_sandbox() -> LoadedWasmSandbox {
     let mut sandbox = SandboxBuilder::new().build().unwrap();
 
     sandbox
@@ -79,7 +75,7 @@ fn get_loaded_wasm_sandbox(ext: &str) -> LoadedWasmSandbox {
     let wasm_sandbox = sandbox.load_runtime().unwrap();
 
     wasm_sandbox
-        .load_module(format!("../../x64/release/RunWasm.{ext}",))
+        .load_module("../../x64/release/RunWasm.aot")
         .unwrap()
 }
 

--- a/src/hyperlight_wasm/benches/benchmarks_components.rs
+++ b/src/hyperlight_wasm/benches/benchmarks_components.rs
@@ -46,8 +46,8 @@ impl bindings::example::runcomponent::RuncomponentImports for State {
 fn wasm_component_guest_call_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("wasm_component_guest_functions");
 
-    let bench_guest_function = |b: &mut Bencher<'_>, ext| {
-        let (sb, rt) = get_loaded_wasm_sandbox(ext);
+    let bench_guest_function = |b: &mut Bencher<'_>| {
+        let (sb, rt) = get_loaded_wasm_sandbox();
         let mut wrapped = bindings::RuncomponentSandbox { sb, rt };
         let instance = bindings::example::runcomponent::RuncomponentExports::guest(&mut wrapped);
 
@@ -56,12 +56,8 @@ fn wasm_component_guest_call_benchmark(c: &mut Criterion) {
         });
     };
 
-    group.bench_function("wasm_guest_call", |b: &mut Bencher<'_>| {
-        bench_guest_function(b, "wasm");
-    });
-
     group.bench_function("wasm_guest_call_aot", |b: &mut Bencher<'_>| {
-        bench_guest_function(b, "aot");
+        bench_guest_function(b);
     });
 
     group.finish();
@@ -70,7 +66,7 @@ fn wasm_component_guest_call_benchmark(c: &mut Criterion) {
 fn wasm_component_sandbox_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("wasm_component_sandboxes");
     let create_wasm_sandbox = || {
-        get_loaded_wasm_sandbox("wasm");
+        get_loaded_wasm_sandbox();
     };
 
     group.bench_function("create_sandbox", |b| {
@@ -84,9 +80,7 @@ fn wasm_component_sandbox_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-fn get_loaded_wasm_sandbox(
-    ext: &str,
-) -> (
+fn get_loaded_wasm_sandbox() -> (
     LoadedWasmSandbox,
     Arc<Mutex<bindings::RuncomponentResources<State>>>,
 ) {
@@ -97,7 +91,7 @@ fn get_loaded_wasm_sandbox(
     let sb = sandbox.load_runtime().unwrap();
 
     let sb = sb
-        .load_module(format!("../../x64/release/runcomponent.{ext}",))
+        .load_module("../../x64/release/runcomponent.aot")
         .unwrap();
     (sb, rt)
 }

--- a/src/hyperlight_wasm/examples/component_example/main.rs
+++ b/src/hyperlight_wasm/examples/component_example/main.rs
@@ -55,7 +55,7 @@ fn main() {
 
     let sb = sb.load_runtime().unwrap();
 
-    let mod_path = get_wasm_module_path("component_sample.wasm").unwrap();
+    let mod_path = get_wasm_module_path("component_sample.aot").unwrap();
     let sb = sb.load_module(mod_path).unwrap();
 
     let mut wrapped = bindings::ExampleSandbox { sb, rt };

--- a/src/hyperlight_wasm/examples/helloworld/main.rs
+++ b/src/hyperlight_wasm/examples/helloworld/main.rs
@@ -26,20 +26,10 @@ fn get_time_since_boot_microsecond() -> Result<i64> {
 }
 
 fn main() -> Result<()> {
-    let tests = vec![
-        (
-            "HelloWorld.wasm",
-            "HelloWorld",
-            "Message from Rust Example to Wasm Function".to_string(),
-        ),
+    let tests = [
         (
             "HelloWorld.aot",
             "HelloWorld",
-            "Message from Rust Example to Wasm Function".to_string(),
-        ),
-        (
-            "RunWasm.wasm",
-            "Echo",
             "Message from Rust Example to Wasm Function".to_string(),
         ),
         (

--- a/src/hyperlight_wasm/examples/hostfuncs/main.rs
+++ b/src/hyperlight_wasm/examples/hostfuncs/main.rs
@@ -39,7 +39,7 @@ fn main() {
     let wasm_sandbox = proto_wasm_sandbox.load_runtime().unwrap();
 
     let mut loaded_wasm_sandbox = {
-        let mod_path = get_wasm_module_path("rust_wasm_samples.wasm").unwrap();
+        let mod_path = get_wasm_module_path("rust_wasm_samples.aot").unwrap();
         wasm_sandbox.load_module(mod_path)
     }
     .unwrap();

--- a/src/hyperlight_wasm/examples/metrics/main.rs
+++ b/src/hyperlight_wasm/examples/metrics/main.rs
@@ -41,7 +41,7 @@ fn main() -> Result<()> {
         let wasm_sandbox = wasm_sandbox.load_runtime()?;
 
         let mut loaded_wasm_sandbox =
-            wasm_sandbox.load_module(get_wasm_module_path("rust_wasm_samples.wasm")?)?;
+            wasm_sandbox.load_module(get_wasm_module_path("rust_wasm_samples.aot")?)?;
 
         loaded_wasm_sandbox
             .call_guest_function::<i32>("add", (5i32, 10i32))

--- a/src/hyperlight_wasm/examples/rust_wasm_examples/main.rs
+++ b/src/hyperlight_wasm/examples/rust_wasm_examples/main.rs
@@ -46,7 +46,7 @@ fn main() -> Result<()> {
         proto_wasm_sandbox.register("TestHostFunc", host_func)?;
 
         let wasm_sandbox = proto_wasm_sandbox.load_runtime()?;
-        let mod_path = get_wasm_module_path("rust_wasm_samples.wasm")?;
+        let mod_path = get_wasm_module_path("rust_wasm_samples.aot")?;
 
         // Load the Wasm module into the sandbox
         let mut loaded_wasm_sandbox = wasm_sandbox.load_module(mod_path)?;

--- a/src/hyperlight_wasm/scripts/build-wasm-examples.sh
+++ b/src/hyperlight_wasm/scripts/build-wasm-examples.sh
@@ -18,10 +18,7 @@ if [ -f "/.dockerenv" ] || grep -q docker /proc/1/cgroup; then
         # Build the wasm file with wasi-libc for wasmtime
         /opt/wasi-sdk/bin/clang -flto -ffunction-sections -mexec-model=reactor -O3 -z stack-size=4096 -Wl,--initial-memory=65536 -Wl,--export=__data_end -Wl,--export=__heap_base,--export=malloc,--export=free,--export=__wasm_call_ctors -Wl,--strip-all,--no-entry -Wl,--allow-undefined -Wl,--gc-sections  -o ${OUTPUT_DIR}/${FILENAME%.*}-wasi-libc.wasm ${FILENAME}
 
-        # Build AOT for Wasmtime; note that Wasmtime does not support
-        # interpreting, so its wasm binary is secretly an AOT binary.
         cargo run -p hyperlight-wasm-aot compile ${OUTPUT_DIR}/${FILENAME%.*}-wasi-libc.wasm ${OUTPUT_DIR}/${FILENAME%.*}.aot
-        cp ${OUTPUT_DIR}/${FILENAME%.*}.aot ${OUTPUT_DIR}/${FILENAME%.*}.wasm
     done
 
     for WIT_FILE in ${PWD}/components/*.wit; do
@@ -43,7 +40,6 @@ if [ -f "/.dockerenv" ] || grep -q docker /proc/1/cgroup; then
 
         # Build AOT for Wasmtime
         cargo run -p hyperlight-wasm-aot compile --component ${OUTPUT_DIR}/${COMPONENT_NAME}-p2.wasm ${OUTPUT_DIR}/${COMPONENT_NAME}.aot
-        cp ${OUTPUT_DIR}/${COMPONENT_NAME}.aot ${OUTPUT_DIR}/${COMPONENT_NAME}.wasm
     done
 
 else 
@@ -62,10 +58,7 @@ else
         # Build the wasm file with wasi-libc for wasmtime
         docker run --rm -i -v "${PWD}:/tmp/host" -v "${OUTPUT_DIR}:/tmp/output/" wasm-clang-builder:latest /opt/wasi-sdk/bin/clang -flto -ffunction-sections -mexec-model=reactor -O3 -z stack-size=4096 -Wl,--initial-memory=65536 -Wl,--export=__data_end -Wl,--export=__heap_base,--export=malloc,--export=free,--export=__wasm_call_ctors -Wl,--strip-all,--no-entry -Wl,--allow-undefined -Wl,--gc-sections  -o /tmp/output/${FILENAME%.*}-wasi-libc.wasm /tmp/host/${FILENAME}
 
-        # Build AOT for Wasmtime; note that Wasmtime does not support
-        # interpreting, so its wasm binary is secretly an AOT binary.
         cargo run -p hyperlight-wasm-aot compile ${OUTPUT_DIR}/${FILENAME%.*}-wasi-libc.wasm ${OUTPUT_DIR}/${FILENAME%.*}.aot
-        cp ${OUTPUT_DIR}/${FILENAME%.*}.aot ${OUTPUT_DIR}/${FILENAME%.*}.wasm
     done
 
     echo Building components
@@ -89,7 +82,6 @@ else
 
         # Build AOT for Wasmtime
         cargo run -p hyperlight-wasm-aot compile --component ${OUTPUT_DIR}/${COMPONENT_NAME}-p2.wasm ${OUTPUT_DIR}/${COMPONENT_NAME}.aot
-        cp ${OUTPUT_DIR}/${COMPONENT_NAME}.aot ${OUTPUT_DIR}/${COMPONENT_NAME}.wasm
     done
 fi
 

--- a/src/hyperlight_wasm/src/sandbox/metrics.rs
+++ b/src/hyperlight_wasm/src/sandbox/metrics.rs
@@ -50,7 +50,7 @@ mod tests {
 
             let wasm_sandbox = sandbox.load_runtime().unwrap();
             let loaded_wasm_sandbox: LoadedWasmSandbox = {
-                let mod_path = get_wasm_module_path("RunWasm.wasm").unwrap();
+                let mod_path = get_wasm_module_path("RunWasm.aot").unwrap();
                 wasm_sandbox.load_module(mod_path).unwrap()
             };
             loaded_wasm_sandbox.unload_module().unwrap();

--- a/src/hyperlight_wasm/src/sandbox/wasm_sandbox.rs
+++ b/src/hyperlight_wasm/src/sandbox/wasm_sandbox.rs
@@ -199,7 +199,7 @@ mod tests {
 
         let loaded = sandbox.load_runtime()?;
 
-        let run_wasm = get_test_file_path("RunWasm.wasm")?;
+        let run_wasm = get_test_file_path("RunWasm.aot")?;
 
         let mut loaded = loaded.load_module(run_wasm)?;
 
@@ -232,7 +232,7 @@ mod tests {
             println!("test_load_module: {name}");
             let wasm_sandbox = sbox_test.sbox;
 
-            let helloworld_wasm = get_test_file_path("HelloWorld.wasm").unwrap();
+            let helloworld_wasm = get_test_file_path("HelloWorld.aot").unwrap();
             let mut loaded_wasm_sandbox = wasm_sandbox.load_module(helloworld_wasm).unwrap();
             let result: i32 = loaded_wasm_sandbox
                 .call_guest_function("HelloWorld", "Message from Rust Test".to_string())
@@ -253,7 +253,7 @@ mod tests {
             let wasm_sandbox = sbox_test.sbox;
 
             let wasm_module_buffer: Vec<u8> =
-                std::fs::read(get_test_file_path("HelloWorld.wasm").unwrap()).unwrap();
+                std::fs::read(get_test_file_path("HelloWorld.aot").unwrap()).unwrap();
             let mut loaded_wasm_sandbox = wasm_sandbox
                 .load_module_from_buffer(&wasm_module_buffer)
                 .unwrap();

--- a/src/hyperlight_wasm_macro/Cargo.lock
+++ b/src/hyperlight_wasm_macro/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-component-util"
 version = "0.7.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?rev=ea6fa8f#ea6fa8f16dae2325d94af39eb6ac3b441b24dcac"
 dependencies = [
  "itertools",
  "log",

--- a/src/wasmsamples/compile-wasm.bat
+++ b/src/wasmsamples/compile-wasm.bat
@@ -25,10 +25,7 @@ for /R "%1" %%i in (*.c) do (
     echo %%~ni.c
     %dockercmd% run --rm -i -v !dockerinput!:/tmp/host1 -v  !dockeroutput!/:/tmp/host2 wasm-clang-builder /opt/wasi-sdk/bin/clang -flto -ffunction-sections -mexec-model=reactor -O3 -z stack-size=4096 -Wl,--initial-memory=65536 -Wl,--export=__data_end -Wl,--export=__heap_base,--export=malloc,--export=free,--export=__wasm_call_ctors -Wl,--strip-all,--no-entry -Wl,--allow-undefined -Wl,--gc-sections -o /tmp/host2/%%~ni.wasm /tmp/host1/%%~ni.c
     echo  %2\%%~ni.wasm
-    rem Build AOT for Wasmtime; note that Wasmtime does not support
-    rem interpreting, so its wasm binary is secretly an AOT binary.
     cargo run -p hyperlight-wasm-aot compile %2\%%~ni.wasm  %2\%%~ni.aot 
-    copy  %2\%%~ni.aot  %2\%%~ni.wasm
 )
 
 echo Building components
@@ -44,7 +41,6 @@ for %%j in (%~1\components\*.wit) do (
 
     rem Build AOT for Wasmtime
     cargo run -p hyperlight-wasm-aot compile --component %2\!COMPONENT_NAME!-p2.wasm %2\!COMPONENT_NAME!.aot
-    copy %2\!COMPONENT_NAME!.aot %2\!COMPONENT_NAME!.wasm
 )
 
 goto :EOF


### PR DESCRIPTION
The files that were being read for the tests as `.wasm` where actually just the `aot` files copied.  This removes that to make it clearer what is happening.