### PR TITLE
Make sure wit is compiled before running benchmarks

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -68,6 +68,9 @@ jobs:
 
     - name: Run Benchmarks
       run: |
+        # the component model benchmark depends on the wasm wit component
+        just ensure-tools
+        just compile-wit
         just bench-ci dev release ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
       working-directory: ./src/hyperlight_wasm
 


### PR DESCRIPTION
after #93 the [release pipeline](https://github.com/hyperlight-dev/hyperlight-wasm/actions/workflows/CreateRelease.yml) is failing with:

```
  error: proc macro panicked
    --> src/component.rs:43:1
     |
  43 | hyperlight_wasm_macro::wasm_guest_bindgen!();
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: message: called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```