### PR TITLE
Adds members excluded from workspace cargo.toml to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
     target-branch: "main"
     labels:
       - "kind/dependencies"
+    ignore:
+      - dependency-name: "wasmtime"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
   # Add entries for excluded workspace members
   - package-ecosystem: "cargo"
     directory: "/src/wasm_runtime"
@@ -25,6 +28,9 @@ updates:
     target-branch: "main"
     labels:
       - "kind/dependencies"
+    ignore:
+      - dependency-name: "wasmtime"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
   - package-ecosystem: "cargo"
     directory: "/src/rust_wasm_samples"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,36 @@ updates:
     target-branch: "main"
     labels:
       - "kind/dependencies"
+  # Add entries for excluded workspace members
+  - package-ecosystem: "cargo"
+    directory: "/src/wasm_runtime"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+    target-branch: "main"
+    labels:
+      - "kind/dependencies"
+  - package-ecosystem: "cargo"
+    directory: "/src/rust_wasm_samples"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+    target-branch: "main"
+    labels:
+      - "kind/dependencies"
+  - package-ecosystem: "cargo"
+    directory: "/src/hyperlight_wasm_macro"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+    target-branch: "main"
+    labels:
+      - "kind/dependencies"
+  - package-ecosystem: "cargo"
+    directory: "/src/component_sample"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+    target-branch: "main"
+    labels:
+      - "kind/dependencies"


### PR DESCRIPTION
Dependabot is only running for workspace members, this adds the excluded members in the workspace to the depandbot job

Ignore major and minor wasmtime versions now we are using v36.0