### PR TITLE
Use Junction instead of symlink on windows

### DIFF
--- a/src/hyperlight_wasm/Cargo.toml
+++ b/src/hyperlight_wasm/Cargo.toml
@@ -75,6 +75,9 @@ anyhow = { version = "1.0" }
 goblin = "0.10.1"
 tar = "0.4.44"
 
+[target.'cfg(windows)'.build-dependencies]
+junction = "1"
+
 [features]
 default = ["function_call_metrics", "kvm", "mshv3"]
 function_call_metrics = ["hyperlight-host/function_call_metrics"]

--- a/src/hyperlight_wasm/build.rs
+++ b/src/hyperlight_wasm/build.rs
@@ -84,7 +84,7 @@ fn get_wasm_runtime_path() -> PathBuf {
     std::os::unix::fs::symlink(crates_dir, &vendor_dir).unwrap();
 
     #[cfg(not(unix))]
-    std::os::windows::fs::symlink_dir(crates_dir, &vendor_dir).unwrap();
+    junction::create(crates_dir, &vendor_dir).unwrap();
 
     let wasm_runtime_dir = crates_dir.join("wasm_runtime");
     if wasm_runtime_dir.exists() {


### PR DESCRIPTION
This pull request updates the way symbolic links are created for the `vendor` directory on Windows during the build process of the `hyperlight_wasm` crate. 

Instead of using the standard library's `symlink_dir`, it now uses the `junction` crate, which does not require admin privileges or developer mode on Windows Additionally, the `junction` crate is added as a build dependency for Windows targets.

