### PR TITLE
Use crates.io trusted publish

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -115,8 +115,6 @@ jobs:
         set -euxo pipefail
         cargo publish -p hyperlight-wasm-aot --dry-run
         cargo publish -p hyperlight-wasm --dry-run
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
       shell: bash
     - name: Publish to crates.io
       if: ${{ contains(github.ref, 'refs/heads/release/') }}


### PR DESCRIPTION
Part of https://github.com/hyperlight-dev/hyperlight/issues/1094

I've updated these crates in crates.io according to https://crates.io/docs/trusted-publishing for these crates