### PR TITLE
Add new benchmark

### DIFF
--- a/src/hyperlight_wasm/benches/benchmarks.rs
+++ b/src/hyperlight_wasm/benches/benchmarks.rs
@@ -74,9 +74,8 @@ fn get_loaded_wasm_sandbox() -> LoadedWasmSandbox {
 
     let wasm_sandbox = sandbox.load_runtime().unwrap();
 
-    wasm_sandbox
-        .load_module("../../x64/release/RunWasm.aot")
-        .unwrap()
+    let aot_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../x64/release/RunWasm.aot");
+    wasm_sandbox.load_module(aot_path).unwrap()
 }
 
 criterion_group! {

--- a/src/hyperlight_wasm/benches/benchmarks_components.rs
+++ b/src/hyperlight_wasm/benches/benchmarks_components.rs
@@ -1,7 +1,10 @@
+use std::ffi::CString;
+use std::io;
+use std::mem::MaybeUninit;
 use std::sync::{Arc, Mutex};
 
-use criterion::{Bencher, Criterion, criterion_group, criterion_main};
-use hyperlight_wasm::{LoadedWasmSandbox, SandboxBuilder};
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use hyperlight_wasm::{LoadedWasmSandbox, SandboxBuilder, WasmSandbox};
 
 use crate::bindings::example::runcomponent::Guest;
 
@@ -80,6 +83,75 @@ fn wasm_component_sandbox_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(not(windows))]
+fn wasm_component_load_call_unload_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("wasm_component_load_call_unload");
+
+    let aot_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../x64/release/runcomponent.aot"
+    );
+    let (mmap_base, mmap_len) = unsafe {
+        let fd = libc::open(CString::new(aot_path).unwrap().as_ptr(), libc::O_RDONLY);
+        assert!(
+            fd >= 0,
+            "couldn't open {}: {:?}",
+            aot_path,
+            io::Error::last_os_error()
+        );
+
+        let mut st = MaybeUninit::<libc::stat>::uninit();
+        libc::fstat(fd, st.as_mut_ptr());
+        let st = st.assume_init();
+
+        let page_size = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+        let len = (st.st_size as usize).next_multiple_of(page_size);
+        let base = libc::mmap(
+            std::ptr::null_mut(),
+            len,
+            libc::PROT_READ | libc::PROT_WRITE | libc::PROT_EXEC,
+            libc::MAP_PRIVATE,
+            fd,
+            0,
+        );
+        libc::close(fd);
+        assert_ne!(
+            base,
+            libc::MAP_FAILED,
+            "mmap failed: {:?}",
+            io::Error::last_os_error()
+        );
+        (base, len)
+    };
+
+    group.bench_function("load_call_unload", |b: &mut Bencher<'_>| {
+        let mut wasm_sandbox = Some({
+            let state = State::new();
+            let mut sandbox = SandboxBuilder::new().build().unwrap();
+            let rt = bindings::register_host_functions(&mut sandbox, state);
+            let sb = sandbox.load_runtime().unwrap();
+            (sb, rt)
+        });
+
+        b.iter(|| {
+            let (ws, rt) = wasm_sandbox.take().unwrap();
+            let loaded = unsafe { ws.load_module_by_mapping(mmap_base, mmap_len).unwrap() };
+            let mut wrapped = bindings::RuncomponentSandbox { sb: loaded, rt };
+            let instance =
+                bindings::example::runcomponent::RuncomponentExports::guest(&mut wrapped);
+            instance.echo("Hello World!".to_string());
+            let unloaded = wrapped.sb.unload_module().unwrap();
+            wasm_sandbox = Some((unloaded, wrapped.rt));
+        });
+    });
+
+    group.finish();
+
+    unsafe {
+        libc::munmap(mmap_base, mmap_len);
+    }
+}
+
 fn get_loaded_wasm_sandbox() -> (
     LoadedWasmSandbox,
     Arc<Mutex<bindings::RuncomponentResources<State>>>,
@@ -90,15 +162,25 @@ fn get_loaded_wasm_sandbox() -> (
 
     let sb = sandbox.load_runtime().unwrap();
 
-    let sb = sb
-        .load_module("../../x64/release/runcomponent.aot")
-        .unwrap();
+    let aot_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../x64/release/runcomponent.aot"
+    );
+    let sb = sb.load_module(aot_path).unwrap();
     (sb, rt)
 }
 
+#[cfg(not(windows))]
 criterion_group! {
     name = benches_components;
     config = Criterion::default();//.warm_up_time(Duration::from_millis(50)); // If warm_up_time is default 3s warmup, the benchmark will fail due memory error
+    targets = wasm_component_guest_call_benchmark, wasm_component_sandbox_benchmark, wasm_component_load_call_unload_benchmark
+}
+
+#[cfg(windows)]
+criterion_group! {
+    name = benches_components;
+    config = Criterion::default();
     targets = wasm_component_guest_call_benchmark, wasm_component_sandbox_benchmark
 }
 criterion_main!(benches_components);


### PR DESCRIPTION
- A new benchmark that does: loading, calling func, unloading. Specifically using `load_module_by_mapping`
- Also fixes some wasmfile paths to ensure benchmarks can be ran from any folder

This is useful to test this specific codepath, which we expect to be the hot-path used by many, and is also the same as used in other benchmarks, and also to easier allow local profiling