### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -5,6 +5,10 @@ name: Benchmarks
 on:
   workflow_call: # this is called from CreateRelease.yml
 
+permissions:
+  contents: read
+  packages: read
+
 # The reason for default shell bash is because on our self-hosted windows runners,
 # the default shell is powershell, which doesn't work correctly together with `just` commands.
 # Even if a command inside a just-recipe fails, github reports the step as successful.


### PR DESCRIPTION
Potential fix for [https://github.com/hyperlight-dev/hyperlight-wasm/security/code-scanning/2](https://github.com/hyperlight-dev/hyperlight-wasm/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/Benchmarks.yml` so all jobs inherit restricted token scopes unless overridden.  
Best minimal fix (without changing behavior) is:

- `contents: read` (needed for checkout/fetch operations)
- `packages: read` (safe/common for dependency/package reads if needed by tools)

Place it near the top-level keys (after `on:` is a clear location). This addresses the CodeQL finding while preserving existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
