### PR TITLE
Remove reference to hyperlight-host executable_heap feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ hyperlight-component-macro = { version = "0.15.0" }
 hyperlight-component-util = { version = "0.15.0" }
 hyperlight-guest = { version = "0.14.0" }
 hyperlight-guest-bin = { version = "0.14.0", features = [ "printf" ] }
-hyperlight-host = { version = "0.14.0", default-features = false, features = ["executable_heap"] }
+hyperlight-host = { version = "0.14.0", default-features = false }
 hyperlight-wasm-macro = { version = "0.14.0", path = "src/hyperlight_wasm_macro" }
 hyperlight-wasm-runtime = { version = "0.14.0", path = "src/hyperlight_wasm_runtime" }


### PR DESCRIPTION
remove feature dependency as its no longer needed and will be removed from hyperlight_host