### PR TITLE
Prepare Hyperlight Wasm v0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Prerelease] - Unreleased
 
+## [v0.15.0] - 2026-08
+
+### Changed
+
+- Adapted component macro generation to the latest `hyperlight-component-util` APIs. (#520)
+- Replaced the deprecated sandbox poison check with the current sandbox status API. (#520)
+- Added support for selecting either the latest or LTS Wasmtime runtime, defaulting to LTS. (#301)
+
 ## [v0.14.0] - 2026-04
 
 ### Changed
@@ -44,7 +52,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 The Initial Hyperlight-wasm Release 🎉 
 
 
-[Prerelease]: <https://github.com/hyperlight-dev/hyperlight-wasm/compare/v0.12.0..HEAD>
+[Prerelease]: <https://github.com/hyperlight-dev/hyperlight-wasm/compare/v0.15.0...HEAD>
+[v0.15.0]: <https://github.com/hyperlight-dev/hyperlight-wasm/compare/v0.14.0...v0.15.0>
+[v0.14.0]: <https://github.com/hyperlight-dev/hyperlight-wasm/compare/v0.12.0...v0.14.0>
 [v0.12.0]: <https://github.com/hyperlight-dev/hyperlight-wasm/compare/v0.11.0...v0.12.0>
 [v0.11.0]: <https://github.com/hyperlight-dev/hyperlight-wasm/compare/v0.10.0...v0.11.0>
 [v0.10.0]: <https://github.com/hyperlight-dev/hyperlight-wasm/compare/v0.9.0...v0.10.0>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm-aot"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cargo-util-schemas",
  "cargo_metadata",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm-macro"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "hyperlight-component-util",
  "itertools 0.15.0",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-wasm-runtime"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cargo_metadata",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = [ "src/tests/rust_guests/rust_wasm_samples", "src/tests/rust_guests/co
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.94"
 license = "Apache-2.0"
@@ -19,5 +19,5 @@ hyperlight-component-util = "0.17.0"
 hyperlight-guest = "0.17.0"
 hyperlight-guest-bin = "0.17.0"
 hyperlight-host = { version = "0.17.0", default-features = false }
-hyperlight-wasm-macro = { version = "0.14.0", path = "src/hyperlight_wasm_macro" }
-hyperlight-wasm-runtime = { version = "0.14.0", path = "src/hyperlight_wasm_runtime" }
+hyperlight-wasm-macro = { version = "0.15.0", path = "src/hyperlight_wasm_macro" }
+hyperlight-wasm-runtime = { version = "0.15.0", path = "src/hyperlight_wasm_runtime" }


### PR DESCRIPTION
## Summary

Prepares the Hyperlight Wasm v0.15.0 release by synchronizing workspace package versions and documenting the release changes and comparison links.

This intentionally builds on the Hyperlight v0.17 dependency migration in the base PR. A full Cargo workspace check remains blocked until the v0.17 Hyperlight crates, including `hyperlight-common`, are published.