### PR TITLE
Update supported Wasmtime versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,9 +609,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -645,11 +645,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d521bdbc6098937af83ef4ab6d5c07398126bc71878f7ef4ea9499977978ef5"
+checksum = "16c273ba1bfc3a1cb27cb4f83df27134f3cb638a61f5ed79ab22cf86eb13da0d"
 dependencies = [
- "cranelift-assembler-x64-meta 0.132.3",
+ "cranelift-assembler-x64-meta 0.134.4",
 ]
 
 [[package]]
@@ -663,11 +663,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dde0b83164d4a497860af4236271178bc640512b067101e0853e4f74eaa4df5"
+checksum = "cbf8909326a466739e83ffe11e74c0c8c6b4bfa911b612aece915daa746cff58"
 dependencies = [
- "cranelift-srcgen 0.132.3",
+ "cranelift-srcgen 0.134.4",
 ]
 
 [[package]]
@@ -681,11 +681,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0111d110b72b4efad69a372e29e21628652fd0bcab66967e5c8350ab679affd5"
+checksum = "3cb26b06b54d8b2f8cdf4d440a32fc3b3b91c71c162333a69a70a66fa265fc45"
 dependencies = [
- "cranelift-entity 0.132.3",
+ "cranelift-entity 0.134.4",
  "wasmtime-internal-core",
 ]
 
@@ -701,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf01ecc92fc5499789d79c3b817299d5a8ddd828d31dcf0f9cc3cc66f38dbb36"
+checksum = "7ce4e57dbb7f73d08011808a19787c3a03c3e7854b2a479ed0b788915fb671be"
 dependencies = [
  "serde",
  "serde_derive",
@@ -739,27 +739,30 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd2563bead0090c3879a7ff7327f7550c9d59bb5d05ecc8cd7886977aa3125a"
+checksum = "74b0a8968f33d0bc13bc86fe70dd3947e93acc9f358ed9848e9988448972a9be"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.132.3",
- "cranelift-bforest 0.132.3",
- "cranelift-bitset 0.132.3",
- "cranelift-codegen-meta 0.132.3",
- "cranelift-codegen-shared 0.132.3",
- "cranelift-control 0.132.3",
- "cranelift-entity 0.132.3",
- "cranelift-isle 0.132.3",
+ "cranelift-assembler-x64 0.134.4",
+ "cranelift-bforest 0.134.4",
+ "cranelift-bitset 0.134.4",
+ "cranelift-codegen-meta 0.134.4",
+ "cranelift-codegen-shared 0.134.4",
+ "cranelift-control 0.134.4",
+ "cranelift-entity 0.134.4",
+ "cranelift-isle 0.134.4",
  "gimli 0.33.0",
  "hashbrown 0.17.1",
  "libm",
  "log",
- "pulley-interpreter 45.0.3",
+ "postcard",
+ "pulley-interpreter 47.0.4",
  "regalloc2 0.15.2",
  "rustc-hash",
  "serde",
+ "serde_derive",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-core",
@@ -780,15 +783,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9640d250d26f9381a73dc7f9862b27928d4809119aec73be0e556612e67b6a99"
+checksum = "f69e8e2fe9deb48ef7b8d0c61612f8c1e2277d0421c201e30a4c844a4ebac698"
 dependencies = [
- "cranelift-assembler-x64-meta 0.132.3",
- "cranelift-codegen-shared 0.132.3",
- "cranelift-srcgen 0.132.3",
+ "cranelift-assembler-x64-meta 0.134.4",
+ "cranelift-codegen-shared 0.134.4",
+ "cranelift-srcgen 0.134.4",
  "heck",
- "pulley-interpreter 45.0.3",
+ "pulley-interpreter 47.0.4",
 ]
 
 [[package]]
@@ -799,9 +802,9 @@ checksum = "ab54b260ef23a8f0f536679b9fc3b3b3e05353e8d1448f3ab83df02078e8be9b"
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07f156b90efc94371ddb3536f76e4ab671ad2e093bfa5511e10198cadbb0c47"
+checksum = "ad4db1e87a65e9c5a832e3ede160830d4e34df938ac38b5604819f8825687e73"
 
 [[package]]
 name = "cranelift-control"
@@ -814,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-control"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a76fd9dd37dcbc3d2d2e00abe3281a7e88adc035fba3b8114cc69981576ec"
+checksum = "9248cd37bb6ec460981f57ead368e32b1eca7a207ad50e3e9c7adc3b161f20e9"
 dependencies = [
  "arbitrary",
 ]
@@ -834,11 +837,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eea22522144ba08c7e7ef94bfc25d474ef016c2771974b8ab1986734ac85965"
+checksum = "26b8bc91c0a3530d132acbf118965dabe9a084029eb0fa74b64760360dec3316"
 dependencies = [
- "cranelift-bitset 0.132.3",
+ "cranelift-bitset 0.134.4",
  "serde",
  "serde_derive",
  "wasmtime-internal-core",
@@ -858,11 +861,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa2826c80dff1d93b19b3cfbcaf9fae44c78d739a98d146dd5bd89c51e14367"
+checksum = "5086f2ebc084a98b387e522680f62ef65a512444d8382151e03088716d3a1714"
 dependencies = [
- "cranelift-codegen 0.132.3",
+ "cranelift-codegen 0.134.4",
+ "hashbrown 0.17.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -876,9 +880,9 @@ checksum = "77b4f73d2288e9480fd2d1d9ab576394dce4805443d6148c6d819dbf78865ce4"
 
 [[package]]
 name = "cranelift-isle"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e238a69b95c5415456f22189494a12db94f313bb72b6ec9cc88ddf2f1056e28e"
+checksum = "b6a658670f779afc2df083be201ebe54805f69b7b9ffa8dab04142b72ed751c9"
 
 [[package]]
 name = "cranelift-native"
@@ -893,11 +897,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eceb0ebd8d6aef6bb287e8d532a164b0db1c0062961211e9c22a91f67521c098"
+checksum = "16a41083b1fd953debd6f32d21fcda765b258f323ce907fdd6b4715f2769c478"
 dependencies = [
- "cranelift-codegen 0.132.3",
+ "cranelift-codegen 0.134.4",
  "libc",
  "target-lexicon",
 ]
@@ -910,9 +914,9 @@ checksum = "4ad4f61ae701d73c326d3df08c366b29ad10f1ba06c245092f217b8d2306746b"
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.132.3"
+version = "0.134.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0"
+checksum = "244d9cd0759b0a3ccdd587cafb13434f9ea43b5c9d07701d277daf5cd0f7b7c1"
 
 [[package]]
 name = "crc32fast"
@@ -1381,6 +1385,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1460,7 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2050,7 +2069,7 @@ dependencies = [
  "clap",
  "object 0.39.1",
  "wasmtime 36.0.14",
- "wasmtime 45.0.3",
+ "wasmtime 47.0.4",
 ]
 
 [[package]]
@@ -2079,7 +2098,7 @@ dependencies = [
  "spin 0.12.3",
  "tracing",
  "wasmtime 36.0.14",
- "wasmtime 45.0.3",
+ "wasmtime 47.0.4",
 ]
 
 [[package]]
@@ -2528,6 +2547,12 @@ checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "managed"
@@ -3161,13 +3186,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04adf8f93264685f2c70a3edb8f828c791e71b22659253319c33f29d1165aef"
+checksum = "ed2bd641cb6a3ec5bffe60405568933163e0ea619da0943e9d2a417ceaa7fe82"
 dependencies = [
- "cranelift-bitset 0.132.3",
+ "cranelift-bitset 0.134.4",
  "log",
- "pulley-macros 45.0.3",
+ "pulley-macros 47.0.4",
  "wasmtime-internal-core",
 ]
 
@@ -3184,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c120a6af1a574a42efcd9df2ad27cb78bc04118c5e0c69e90599f17301a1c7a"
+checksum = "d3fd4024d1e559eaf5579bc8ad84a2b5915f34b47acc13a06ffba7dac401b166"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3377,6 +3402,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "rustc-hash",
+ "serde",
  "smallvec",
 ]
 
@@ -4526,12 +4552,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.248.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.248.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -4571,9 +4597,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.248.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags 2.13.1",
  "hashbrown 0.17.1",
@@ -4608,13 +4634,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.248.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+checksum = "7142797de29b35ab8dbf15c00f55fda75d409da4c423a8ab8bd6b667a785824b"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.248.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -4634,7 +4660,7 @@ dependencies = [
  "indexmap",
  "libc",
  "log",
- "mach2",
+ "mach2 0.4.3",
  "memfd",
  "object 0.37.3",
  "once_cell",
@@ -4659,15 +4685,15 @@ dependencies = [
  "wasmtime-internal-slab",
  "wasmtime-internal-unwinder 36.0.14",
  "wasmtime-internal-versioned-export-macros 36.0.14",
- "wasmtime-internal-winch 36.0.14",
+ "wasmtime-internal-winch",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a83ef84ac8bab735c89e27b0268b0586099fbe81281ae45be2b8e4f407b2daa"
+checksum = "4cdaf5b8af5713146e3a62d940c71e3eb2ad1ebacfa6b55f0c8509a5b4b87718"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -4676,32 +4702,32 @@ dependencies = [
  "cc",
  "cfg-if",
  "encoding_rs",
+ "futures",
  "libc",
  "log",
- "mach2",
+ "mach2 0.6.0",
  "memfd",
  "object 0.39.1",
  "once_cell",
  "postcard",
- "pulley-interpreter 45.0.3",
+ "pulley-interpreter 47.0.4",
  "rustix",
  "semver",
  "serde",
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.248.0",
- "wasmtime-environ 45.0.3",
- "wasmtime-internal-component-macro 45.0.3",
- "wasmtime-internal-component-util 45.0.3",
+ "wasmparser 0.252.0",
+ "wasmtime-environ 47.0.4",
+ "wasmtime-internal-component-macro 47.0.4",
+ "wasmtime-internal-component-util 47.0.4",
  "wasmtime-internal-core",
- "wasmtime-internal-cranelift 45.0.3",
- "wasmtime-internal-fiber 45.0.3",
- "wasmtime-internal-jit-debug 45.0.3",
- "wasmtime-internal-jit-icache-coherence 45.0.3",
- "wasmtime-internal-unwinder 45.0.3",
- "wasmtime-internal-versioned-export-macros 45.0.3",
- "wasmtime-internal-winch 45.0.3",
+ "wasmtime-internal-cranelift 47.0.4",
+ "wasmtime-internal-fiber 47.0.4",
+ "wasmtime-internal-jit-debug 47.0.4",
+ "wasmtime-internal-jit-icache-coherence 47.0.4",
+ "wasmtime-internal-unwinder 47.0.4",
+ "wasmtime-internal-versioned-export-macros 47.0.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4732,15 +4758,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439686d3deb38525c86b88bbc90f7ba669f70c8edc7d6b35147c738bbef5ff76"
+checksum = "58793271eab7ec26bab99ca497131f8b37702e7dc39e2f2d18293e3e915b4964"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-bforest 0.132.3",
- "cranelift-bitset 0.132.3",
- "cranelift-entity 0.132.3",
+ "cranelift-bforest 0.134.4",
+ "cranelift-bitset 0.134.4",
+ "cranelift-entity 0.134.4",
  "gimli 0.33.0",
  "hashbrown 0.17.1",
  "indexmap",
@@ -4754,10 +4780,10 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wasmprinter 0.248.0",
- "wasmtime-internal-component-util 45.0.3",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
+ "wasmprinter 0.252.0",
+ "wasmtime-internal-component-util 47.0.4",
  "wasmtime-internal-core",
 ]
 
@@ -4787,17 +4813,17 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d2c5850fb8c448792453765d97f6f01096a32708f3c36798e86220763c90c0"
+checksum = "c5bba4eff4804620bae04d7793308d97a0c5a8a97ea19e635452518f84560f84"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "wasmtime-internal-component-util 45.0.3",
- "wasmtime-internal-wit-bindgen 45.0.3",
- "wit-parser 0.248.0",
+ "wasmtime-internal-component-util 47.0.4",
+ "wasmtime-internal-wit-bindgen 47.0.4",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
@@ -4808,15 +4834,15 @@ checksum = "1c3e218b51d2ef9eb181499e42c691512c1bc11dd6dc7746807a9b2b9290369c"
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed79c4e9ab416dcc5e46b9d1ec9b7c2e3c730deab525996b0de45a35fc8b2c3"
+checksum = "3d7032ff6b4d7a45e05be1cb32ec1756df5f2669f08296dbe2c61c3789dead2c"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3073c03f97f871fe6400e68621c863b93ba79296f8e570285231952d23fcc804"
+checksum = "f41d3b2cb9c3de7b696690af070d408b5e357011832f8b8bb7fbb315dbb620ed"
 dependencies = [
  "hashbrown 0.17.1",
  "libm",
@@ -4852,29 +4878,29 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a15981261d361f9c93b42929f446b4009840853ceea181ad6e17730f4016a0b"
+checksum = "1d5cda5b90247978dd2ba6ca4e309508da19e9244445671d2d0e6a34e5c3b847"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.132.3",
- "cranelift-control 0.132.3",
- "cranelift-entity 0.132.3",
- "cranelift-frontend 0.132.3",
- "cranelift-native 0.132.3",
+ "cranelift-codegen 0.134.4",
+ "cranelift-control 0.134.4",
+ "cranelift-entity 0.134.4",
+ "cranelift-frontend 0.134.4",
+ "cranelift-native 0.134.4",
  "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
  "object 0.39.1",
- "pulley-interpreter 45.0.3",
+ "pulley-interpreter 47.0.4",
  "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.248.0",
- "wasmtime-environ 45.0.3",
+ "wasmparser 0.252.0",
+ "wasmtime-environ 47.0.4",
  "wasmtime-internal-core",
- "wasmtime-internal-unwinder 45.0.3",
- "wasmtime-internal-versioned-export-macros 45.0.3",
+ "wasmtime-internal-unwinder 47.0.4",
+ "wasmtime-internal-versioned-export-macros 47.0.4",
 ]
 
 [[package]]
@@ -4895,16 +4921,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33aed9d91d54c9f861ba7e3c3130bded8a7a63e01fe58c3a9a36b45d6ee0fb57"
+checksum = "4d126366176553e8f304e8ac2078a4cc37134fe8f19d4d4695a09c5a2f577f10"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "rustix",
- "wasmtime-environ 45.0.3",
- "wasmtime-internal-versioned-export-macros 45.0.3",
+ "wasmtime-environ 47.0.4",
+ "wasmtime-internal-versioned-export-macros 47.0.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4920,12 +4946,12 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944942118aab67e7b4febfe88a65d0af4cfd10af8ed0e79fd6cf39d75359ab7e"
+checksum = "c1d28ff131bc40e11d84bc3a9fa0d264506439ffbbc89f3562fbb529d1caa617"
 dependencies = [
  "cc",
- "wasmtime-internal-versioned-export-macros 45.0.3",
+ "wasmtime-internal-versioned-export-macros 47.0.4",
 ]
 
 [[package]]
@@ -4942,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37dee05e8c35759826f6b926cd949c51f771b6a58619d8e60c63c3f3d3e5e59b"
+checksum = "4a52de8b6afbfcd618073f592c1450cb661574e7061f3f4a44f1f7ec0c7f7909"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4982,15 +5008,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a83f7ebe911a6f1605ff0d3a678472ddb1fcc57c3e2f6bae5dd4d170b625b3ed"
+checksum = "5524fbaaf3d2134dd6229164d7fc81e443cce06d1e0576524d5f4e86e747cb13"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.132.3",
+ "cranelift-codegen 0.134.4",
  "log",
  "object 0.39.1",
- "wasmtime-environ 45.0.3",
+ "wasmtime-environ 47.0.4",
 ]
 
 [[package]]
@@ -5006,9 +5032,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75980644456dc003238766254b0e5f002704630237ccd0728747991fe2739d7"
+checksum = "e93bb9ae112a80618510f938275a5d88637b656e7d0a021fc906f52206c708ad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5029,24 +5055,7 @@ dependencies = [
  "wasmparser 0.236.1",
  "wasmtime-environ 36.0.14",
  "wasmtime-internal-cranelift 36.0.14",
- "winch-codegen 36.0.14",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
-version = "45.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81af36995b4720b32e3d667541b548a27184a859d09a6ee745eaba095f5a6f6e"
-dependencies = [
- "cranelift-codegen 0.132.3",
- "gimli 0.33.0",
- "log",
- "object 0.39.1",
- "target-lexicon",
- "wasmparser 0.248.0",
- "wasmtime-environ 45.0.3",
- "wasmtime-internal-cranelift 45.0.3",
- "winch-codegen 45.0.3",
+ "winch-codegen",
 ]
 
 [[package]]
@@ -5064,15 +5073,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "45.0.3"
+version = "47.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada06667b7948892703fcc9f0b9b337c2e78c334d74d4fa62e2f75f07fbb3659"
+checksum = "bfdbdd9d6fab1ecb67a7dc189e32c9e341444945fb709437bf8aab25d9a88459"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",
  "heck",
  "indexmap",
- "wit-parser 0.248.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
@@ -5176,25 +5185,6 @@ dependencies = [
  "wasmtime-environ 36.0.14",
  "wasmtime-internal-cranelift 36.0.14",
  "wasmtime-internal-math",
-]
-
-[[package]]
-name = "winch-codegen"
-version = "45.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73bc25d27222248f9bafc7e9945f61e74275360c3ea0d34008810d436140a53"
-dependencies = [
- "cranelift-assembler-x64 0.132.3",
- "cranelift-codegen 0.132.3",
- "gimli 0.33.0",
- "regalloc2 0.15.2",
- "smallvec",
- "target-lexicon",
- "thiserror",
- "wasmparser 0.248.0",
- "wasmtime-environ 45.0.3",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift 45.0.3",
 ]
 
 [[package]]
@@ -5526,9 +5516,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.248.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -5539,8 +5529,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
- "wasmparser 0.248.0",
+ "unicode-ident",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]

--- a/src/hyperlight_wasm_aot/Cargo.toml
+++ b/src/hyperlight_wasm_aot/Cargo.toml
@@ -15,8 +15,8 @@ Application to precompile WebAssembly binaries to for hyperlight-wasm.
 # Since we can use the library with either the latest bundled wasmtime or the LTS version
 # we need to bundle both here as dependencies.
 # The default is the LTS version. To use the latest version pass --wasmtime-version latest.
-wasmtime = { version = "45.0.2", default-features = false, features = ["cranelift", "pulley", "runtime", "component-model"] }
-wasmtime_lts = { package = "wasmtime", version = "36.0.11", default-features = false, features = ["cranelift", "pulley", "runtime", "component-model"] }
+wasmtime = { version = "47.0.4", default-features = false, features = ["cranelift", "pulley", "runtime", "component-model"] }
+wasmtime_lts = { package = "wasmtime", version = "36.0.14", default-features = false, features = ["cranelift", "pulley", "runtime", "component-model"] }
 clap = { version = "4.6", features = ["derive"] }
 cargo_metadata = "0.23"
 cargo-util-schemas = "=0.14.1"

--- a/src/hyperlight_wasm_runtime/Cargo.toml
+++ b/src/hyperlight_wasm_runtime/Cargo.toml
@@ -30,8 +30,8 @@ hyperlight-guest.workspace = true
 hyperlight-wasm-macro.workspace = true
 # Default to the LTS wasmtime version; use wasmtime_latest to opt into latest.
 # These are marked optional to avoid pulling them both in. They should be mutually exclusive.
-wasmtime = { version = "45.0.2", default-features = false, features = [ "runtime", "custom-virtual-memory", "custom-native-signals", "component-model" ], optional = true }
-wasmtime_lts = { package = "wasmtime", version = "36.0.11", default-features = false, features = [ "runtime", "custom-virtual-memory", "custom-native-signals", "component-model" ], optional = true }
+wasmtime = { version = "47.0.4", default-features = false, features = [ "runtime", "custom-virtual-memory", "custom-native-signals", "component-model" ], optional = true }
+wasmtime_lts = { package = "wasmtime", version = "36.0.14", default-features = false, features = [ "runtime", "custom-virtual-memory", "custom-native-signals", "component-model" ], optional = true }
 spin = "0.12.0"
 tracing = { version = "0.1.44", default-features = false, features = ["attributes", "log"] }
 

--- a/src/hyperlight_wasm_runtime/src/platform.rs
+++ b/src/hyperlight_wasm_runtime/src/platform.rs
@@ -304,15 +304,30 @@ pub extern "C" fn wasmtime_memory_image_free(_image: *mut c_void) {
 }
 
 /* Because we only have a single thread in the guest at the moment, we
- * don't need real thread-local storage. */
-static FAKE_TLS: AtomicPtr<u8> = AtomicPtr::new(core::ptr::null_mut());
+ * don't need real thread-local storage. Wasmtime 47 introduced indexed
+ * TLS slots, while the LTS release still uses a single implicit slot. */
+static FAKE_TLS: [AtomicPtr<u8>; 2] = [const { AtomicPtr::new(core::ptr::null_mut()) }; 2];
+
+#[cfg(feature = "wasmtime_lts")]
 #[no_mangle]
 pub extern "C" fn wasmtime_tls_get() -> *mut u8 {
-    FAKE_TLS.load(Ordering::Acquire)
+    FAKE_TLS[0].load(Ordering::Acquire)
 }
+#[cfg(feature = "wasmtime_lts")]
 #[no_mangle]
 pub extern "C" fn wasmtime_tls_set(ptr: *mut u8) {
-    FAKE_TLS.store(ptr, Ordering::Release)
+    FAKE_TLS[0].store(ptr, Ordering::Release)
+}
+
+#[cfg(not(feature = "wasmtime_lts"))]
+#[no_mangle]
+pub extern "C" fn wasmtime_tls_get(slot: usize) -> *mut u8 {
+    FAKE_TLS[slot].load(Ordering::Acquire)
+}
+#[cfg(not(feature = "wasmtime_lts"))]
+#[no_mangle]
+pub extern "C" fn wasmtime_tls_set(slot: usize, ptr: *mut u8) {
+    FAKE_TLS[slot].store(ptr, Ordering::Release)
 }
 
 pub struct WasmtimeCodeMemory {}


### PR DESCRIPTION
Updates both supported Wasmtime tracks to the newest releases compatible with Rust 1.94. The default LTS track moves to 36.0.14 and the opt-in latest track moves to 47.0.4, keeping runtime and AOT compilation aligned without requiring Rust 1.95.
