### PR TITLE
Stabilize PR and release CI

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -7,7 +7,8 @@ on:
 
 permissions:
   contents: read
-  packages: read
+  # dep_build_wasm_examples.yml publishes the shared builder cache to GHCR.
+  packages: write
 
 # The reason for default shell bash is because on our self-hosted windows runners,
 # the default shell is powershell, which doesn't work correctly together with `just` commands.
@@ -27,7 +28,9 @@ jobs:
     needs:
       - build-wasm-examples
     strategy:
-      fail-fast: true
+      # A lost self-hosted runner should not cancel benchmark artifacts from
+      # otherwise healthy matrix jobs.
+      fail-fast: false
       matrix:
         hypervisor: [hyperv, mshv3, kvm] # hyperv is windows, mshv and kvm are linux
         cpu: [amd, intel]

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -7,8 +7,7 @@ on:
 
 permissions:
   contents: read
-  # dep_build_wasm_examples.yml publishes the shared builder cache to GHCR.
-  packages: write
+  packages: read
 
 # The reason for default shell bash is because on our self-hosted windows runners,
 # the default shell is powershell, which doesn't work correctly together with `just` commands.

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -17,7 +17,7 @@ jobs:
 
   publish:
     # see https://github.com/orgs/community/discussions/26286#discussioncomment-3251208 for why we need to check the ref
-    if: ${{ contains(github.ref, 'refs/heads/release/') }} ||  ${{ github.ref=='refs/heads/main' }}
+    if: ${{ contains(github.ref, 'refs/heads/release/') || github.ref == 'refs/heads/main' }}
     needs: [ benchmarks ]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -17,7 +17,7 @@ jobs:
 
   publish:
     # see https://github.com/orgs/community/discussions/26286#discussioncomment-3251208 for why we need to check the ref
-    if: ${{ contains(github.ref, 'refs/heads/release/') || github.ref == 'refs/heads/main' }}
+    if: ${{ contains(github.ref, 'refs/heads/release/') }} ||  ${{ github.ref=='refs/heads/main' }}
     needs: [ benchmarks ]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -62,6 +62,7 @@ jobs:
       # On Linux, always pass the hypervisor feature (kvm/mshv3).
       # On Linux latest builds, also add wasmtime_latest.
       FEATURES: ${{ matrix.hypervisor != 'hyperv' && format('{0}{1}', matrix.hypervisor, matrix.wasmtime == 'latest' && ',wasmtime_latest' || '') || (matrix.wasmtime == 'latest' && 'wasmtime_latest' || '') }}
+      RUN_BENCHMARKS: ${{ matrix.config == 'release' && (matrix.wasmtime == 'lts' || (matrix.hypervisor == 'kvm' && matrix.cpu == 'amd')) }}
     steps:
       - uses: actions/checkout@v5
 
@@ -145,10 +146,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
         working-directory: ./src/hyperlight_wasm
-        if: ${{ matrix.config == 'release' }}
+        if: ${{ env.RUN_BENCHMARKS == 'true' }}
 
       - name: Run benchmarks
         run: |
           just bench-ci dev ${{ matrix.config }} ${{ env.FEATURES }}
         working-directory: ./src/hyperlight_wasm
-        if: ${{ matrix.config == 'release' }}
+        if: ${{ env.RUN_BENCHMARKS == 'true' }}

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -146,14 +146,11 @@ jobs:
       matrix:
         hypervisor: [hyperv, mshv3, kvm]
         cpu: [amd, intel]
-        wasmtime: [latest, lts]
-        exclude:
-          - wasmtime: latest
-            hypervisor: hyperv
-          - wasmtime: latest
-            hypervisor: mshv3
-          - wasmtime: latest
-            cpu: intel
+        wasmtime: [lts]
+        include:
+          - hypervisor: kvm
+            cpu: amd
+            wasmtime: latest
 
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}", "JobId=benchmark-{3}-{4}-{5}-{6}"]',

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -35,7 +35,9 @@ jobs:
   build:
     if: ${{ inputs.docs_only == 'false' }}
     strategy:
-        fail-fast: true
+        # Preserve completed shards when an ephemeral runner disconnects so a
+        # failed-job rerun does not need to repeat the entire matrix.
+        fail-fast: false
         matrix:
           hypervisor: [hyperv, mshv3, kvm] # hyperv is windows, mshv and kvm are linux
           cpu: [amd, intel]

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -49,11 +49,12 @@ jobs:
               config: debug
   
     runs-on: ${{ fromJson(
-        format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}", "JobId=build-{3}-{4}-{5}-{6}"]', 
+        format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}", "JobId=build-{3}-{4}-{5}-{6}-{7}"]',
           matrix.hypervisor == 'hyperv' && 'Windows' || 'Linux', 
           matrix.hypervisor == 'hyperv' && 'win2025' || matrix.hypervisor == 'mshv3' && 'azlinux3-mshv' || matrix.hypervisor, 
           matrix.cpu,
           matrix.config,
+          matrix.wasmtime,
           github.run_id,
           github.run_number,
           github.run_attempt)) }} 
@@ -64,7 +65,7 @@ jobs:
       # On Linux, always pass the hypervisor feature (kvm/mshv3).
       # On Linux latest builds, also add wasmtime_latest.
       FEATURES: ${{ matrix.hypervisor != 'hyperv' && format('{0}{1}', matrix.hypervisor, matrix.wasmtime == 'latest' && ',wasmtime_latest' || '') || (matrix.wasmtime == 'latest' && 'wasmtime_latest' || '') }}
-      RUN_BENCHMARKS: ${{ matrix.config == 'release' && (matrix.wasmtime == 'lts' || (matrix.hypervisor == 'kvm' && matrix.cpu == 'amd')) }}
+      RUN_EXAMPLES: ${{ (matrix.config == 'debug' && matrix.wasmtime == 'lts') || (matrix.config == 'release' && matrix.wasmtime == 'latest' && matrix.hypervisor == 'kvm' && matrix.cpu == 'amd') }}
     steps:
       - uses: actions/checkout@v5
 
@@ -133,25 +134,64 @@ jobs:
         shell: pwsh
 
       - name: Test Examples
+        if: ${{ env.RUN_EXAMPLES == 'true' }}
         run: just examples-ci ${{ matrix.config }} ${{ env.FEATURES }}
         working-directory: ./src/hyperlight_wasm
         env:
           # required for gh cli when downloading
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      ### Benchmarks ###
+
+  benchmark:
+    if: ${{ inputs.docs_only == 'false' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        hypervisor: [hyperv, mshv3, kvm]
+        cpu: [amd, intel]
+        wasmtime: [latest, lts]
+        exclude:
+          - wasmtime: latest
+            hypervisor: hyperv
+          - wasmtime: latest
+            hypervisor: mshv3
+          - wasmtime: latest
+            cpu: intel
+
+    runs-on: ${{ fromJson(
+        format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}", "JobId=benchmark-{3}-{4}-{5}-{6}"]',
+          matrix.hypervisor == 'hyperv' && 'Windows' || 'Linux',
+          matrix.hypervisor == 'hyperv' && 'win2025' || matrix.hypervisor == 'mshv3' && 'azlinux3-mshv' || matrix.hypervisor,
+          matrix.cpu,
+          matrix.wasmtime,
+          github.run_id,
+          github.run_number,
+          github.run_attempt)) }}
+    env:
+      FEATURES: ${{ matrix.hypervisor != 'hyperv' && format('{0}{1}', matrix.hypervisor, matrix.wasmtime == 'latest' && ',wasmtime_latest' || '') || (matrix.wasmtime == 'latest' && 'wasmtime_latest' || '') }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Hyperlight setup
+        uses: hyperlight-dev/ci-setup-workflow@v1.8.0
+        with:
+          rust-toolchain: "1.94"
+
+      - name: Download Wasm Modules
+        uses: actions/download-artifact@v5
+        with:
+          name: guest-modules-${{ matrix.wasmtime }}
+          path: ./x64/release
 
       - name: Download benchmarks from "latest"
-        run: |
-          just bench-download ${{ runner.os }} ${{ matrix.hypervisor }} ${{ matrix.cpu }} dev-latest
+        run: just bench-download ${{ runner.os }} ${{ matrix.hypervisor }} ${{ matrix.cpu }} dev-latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
         working-directory: ./src/hyperlight_wasm
-        if: ${{ env.RUN_BENCHMARKS == 'true' }}
 
       - name: Run benchmarks
         run: |
-          just bench-ci dev ${{ matrix.config }} ${{ env.FEATURES }}
+          just ensure-tools
+          just compile-wit
+          just bench-ci dev release ${{ env.FEATURES }}
         working-directory: ./src/hyperlight_wasm
-        if: ${{ env.RUN_BENCHMARKS == 'true' }}

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -65,7 +65,6 @@ jobs:
       # On Linux, always pass the hypervisor feature (kvm/mshv3).
       # On Linux latest builds, also add wasmtime_latest.
       FEATURES: ${{ matrix.hypervisor != 'hyperv' && format('{0}{1}', matrix.hypervisor, matrix.wasmtime == 'latest' && ',wasmtime_latest' || '') || (matrix.wasmtime == 'latest' && 'wasmtime_latest' || '') }}
-      RUN_EXAMPLES: ${{ (matrix.config == 'debug' && matrix.wasmtime == 'lts') || (matrix.config == 'release' && matrix.wasmtime == 'latest' && matrix.hypervisor == 'kvm' && matrix.cpu == 'amd') }}
     steps:
       - uses: actions/checkout@v5
 
@@ -134,7 +133,6 @@ jobs:
         shell: pwsh
 
       - name: Test Examples
-        if: ${{ env.RUN_EXAMPLES == 'true' }}
         run: just examples-ci ${{ matrix.config }} ${{ env.FEATURES }}
         working-directory: ./src/hyperlight_wasm
         env:


### PR DESCRIPTION
## Summary

Give every Wasmtime matrix shard a unique 1ES runner identity and run seven benchmarks on fresh isolated runners. Build, Clippy, tests, and examples retain the full matrix.

This addresses the observed runner collisions and removes the benchmark tail from build jobs, while `fail-fast: false` prevents one lost runner from canceling healthy shards.