### PR TITLE
Fix benchmark workflow package permission

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  packages: read
+  packages: write
 
 # The reason for default shell bash is because on our self-hosted windows runners,
 # the default shell is powershell, which doesn't work correctly together with `just` commands.


### PR DESCRIPTION
The release workflow has failed during startup since benchmark permissions were restricted to package reads in #541. Allow the reusable benchmark workflow to write packages so its nested Wasm example build can use the required registry cache permissions without attempting an invalid permission elevation.